### PR TITLE
Draft: Off-main-thread compilation and other performance improvements

### DIFF
--- a/src/analysis/codestyleanalyzer.vala
+++ b/src/analysis/codestyleanalyzer.vala
@@ -83,7 +83,7 @@ class Vls.CodeStyleAnalyzer : CodeVisitor, CodeAnalyzer {
         // parse tree (to allow for fast code completion), we have to use
         // [last_fresh_content]
         unowned var content = (current_file is TextDocument) ?
-            ((TextDocument)current_file).last_fresh_content : current_file.content;
+            ((TextDocument)current_file).last_compiled_content : current_file.content;
         var sr = callable.source_reference;
         var zero_idx = (long) Util.get_string_pos (content, sr.end.line - 1, sr.end.column);
         unowned string text = content.offset (zero_idx);

--- a/src/codehelp/codehelp.vala
+++ b/src/codehelp/codehelp.vala
@@ -74,7 +74,7 @@ namespace Vls.CodeHelp {
         if (file.content == null)
             file.content = (string) file.get_mapped_contents ();
         if (sr.file is TextDocument) {
-            content = ((TextDocument)sr.file).last_fresh_content;
+            content = ((TextDocument)sr.file).last_compiled_content;
         } else {
             content = file.content;
         }

--- a/src/codehelp/codelensengine.vala
+++ b/src/codehelp/codelensengine.vala
@@ -122,7 +122,9 @@ namespace Vls.CodeLensEngine {
     async void begin_response_async (Server lang_serv, Project project,
                                Jsonrpc.Client client, Variant id, string method,
                                Vala.SourceFile doc, Compilation compilation) {
-        if (!yield lang_serv.wait_for_context_update_async (id, method)) {
+        try {
+            yield lang_serv.wait_for_context_update_async (id, method);
+        } catch (Error e) {
             yield Server.reply_null_async (id, client, method);
             return;
         }

--- a/src/codehelp/codelensengine.vala
+++ b/src/codehelp/codelensengine.vala
@@ -122,13 +122,6 @@ namespace Vls.CodeLensEngine {
     async void begin_response_async (Server lang_serv, Project project,
                                Jsonrpc.Client client, Variant id, string method,
                                Vala.SourceFile doc, Compilation compilation) {
-        try {
-            yield lang_serv.wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield Server.reply_null_async (id, client, method);
-            return;
-        }
-
         Vala.CodeContext.push (compilation.code_context);
         var collected_symbols = compilation.get_analysis_for_file<CodeLensAnalyzer> (doc) as CodeLensAnalyzer;
         Vala.CodeContext.pop ();

--- a/src/codehelp/completionengine.vala
+++ b/src/codehelp/completionengine.vala
@@ -107,7 +107,9 @@ namespace Vls.CompletionEngine {
 
             if (completions.is_empty) {
                 // debug ("[%s] trying MA completion again after context update ...", method);
-                if (!yield lang_serv.wait_for_context_update_async (id, method)) {
+                try {
+                    yield lang_serv.wait_for_context_update_async (id, method);
+                } catch (Error e) {
                     yield Server.reply_null_async (id, client, method);
                     return;
                 }

--- a/src/codehelp/signaturehelpengine.vala
+++ b/src/codehelp/signaturehelpengine.vala
@@ -51,7 +51,9 @@ namespace Vls.SignatureHelpEngine {
         }
         
         if (signatures.is_empty) {
-            if (!yield lang_serv.wait_for_context_update_async (id, method)) {
+            try {
+                yield lang_serv.wait_for_context_update_async (id, method);
+            } catch (Error e) {
                 Vala.CodeContext.pop ();
                 yield Server.reply_null_async (id, client, method);
                 return;

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,6 +29,7 @@ vls_src = files([
   'reporter.vala',
   'server.vala',
   'servertypes.vala',
+  'scheduler.vala'
 ])
 
 if get_option('active_parameter')

--- a/src/projects/buildtarget.vala
+++ b/src/projects/buildtarget.vala
@@ -51,7 +51,7 @@ abstract class Vls.BuildTarget : Object, Hashable<BuildTarget> {
      * its dependencies are newer than this target. This does not take care of 
      * building the target's dependencies.
      */
-    public abstract void build_if_stale (Cancellable? cancellable = null) throws Error;
+    public abstract async void rebuild_async (Cancellable? cancellable = null) throws Error;
 
     public bool equal_to (BuildTarget other) {
         return output_dir == other.output_dir && name == other.name && id == other.id;

--- a/src/projects/ccproject.vala
+++ b/src/projects/ccproject.vala
@@ -28,7 +28,7 @@ class Vls.CcProject : Project {
 
     private string build_dir;
 
-    public override bool reconfigure_if_stale (Cancellable? cancellable = null) throws Error {
+    public override async bool reconfigure_async (Cancellable? cancellable = null) throws Error {
         if (!build_files_have_changed) {
             return false;
         }
@@ -72,10 +72,10 @@ class Vls.CcProject : Project {
                                                     cc.command[0:1], cc.command[1:cc.command.length],
                                                     new string[]{}, new string[]{}, new string[]{}));
             else
-                build_targets.add (new BuildTask (cc.directory, cc.directory, cc.file ?? @"CC#$i", @"CC#$i", i,
-                                                  cc.command[0:1], cc.command[1:cc.command.length], 
-                                                  new string[]{}, new string[]{},
-                                                  new string[]{}, "unknown"));
+                build_targets.add (yield new BuildTask (cc.directory, cc.directory, cc.file ?? @"CC#$i", @"CC#$i", i,
+                                                        cc.command[0:1], cc.command[1:cc.command.length], 
+                                                        new string[]{}, new string[]{},
+                                                        new string[]{}, "unknown"));
         }
 
         analyze_build_targets (cancellable);
@@ -83,7 +83,7 @@ class Vls.CcProject : Project {
         return true;
     }
 
-    public CcProject (string root_path, string cc_location, Cancellable? cancellable = null) throws Error {
+    public async CcProject (string root_path, string cc_location, Cancellable? cancellable = null) throws Error {
         base (root_path);
 
         var root_dir = File.new_for_path (root_path);
@@ -97,7 +97,7 @@ class Vls.CcProject : Project {
         this.build_dir = cc_json_file.get_parent ().get_path ();
         this.cc_json_file = cc_json_file;
 
-        reconfigure_if_stale (cancellable);
+        yield reconfigure_async (cancellable);
     }
 
     private void file_changed_event (File src, File? dest, FileMonitorEvent event_type) {

--- a/src/projects/ccproject.vala
+++ b/src/projects/ccproject.vala
@@ -46,7 +46,7 @@ class Vls.CcProject : Project {
         }
 
         var parser = new Json.Parser.immutable_new ();
-        parser.load_from_stream (cc_json_file.read (cancellable), cancellable);
+        yield parser.load_from_stream_async (yield cc_json_file.read_async (GLib.Priority.DEFAULT, cancellable), cancellable);
         Json.Node? cc_json_root = parser.get_root ();
 
         if (cc_json_root == null)

--- a/src/projects/compilation.vala
+++ b/src/projects/compilation.vala
@@ -396,10 +396,6 @@ class Vls.Compilation : BuildTarget {
     }
 
     public override async void rebuild_async (Cancellable? cancellable = null) throws Error {
-        if (_project_sources.is_empty)
-            // configure for first time
-            configure (cancellable);
-
         bool stale = false;
         foreach (BuildTarget dep in dependencies.values) {
             if (dep.last_updated.compare (last_updated) > 0) {

--- a/src/projects/compilation.vala
+++ b/src/projects/compilation.vala
@@ -395,7 +395,7 @@ class Vls.Compilation : BuildTarget {
         debug ("finished compiling %s", id);
     }
 
-    public override void build_if_stale (Cancellable? cancellable = null) throws Error {
+    public override async void rebuild_async (Cancellable? cancellable = null) throws Error {
         if (_project_sources.is_empty)
             // configure for first time
             configure (cancellable);

--- a/src/projects/compilation.vala
+++ b/src/projects/compilation.vala
@@ -224,9 +224,9 @@ class Vls.Compilation : BuildTarget {
         }
     }
 
-    private void configure (Cancellable? cancellable = null) throws Error {
+    private async void compile_async (Cancellable? cancellable = null) throws Error {
         // 1. recreate code context
-        code_context = new Vala.CodeContext () {
+        var code_context = new Vala.CodeContext () {
             deprecated = _deprecated,
             experimental = _experimental,
             experimental_non_null = _experimental_non_null,
@@ -287,11 +287,12 @@ class Vls.Compilation : BuildTarget {
             }
         }
 
-        foreach (TextDocument doc in _project_sources.values) {
-            doc.context = code_context;
+        var new_project_sources = new HashMap<File, TextDocument> (Util.file_hash, Util.file_equal);
+
+        foreach (Map.Entry<File, TextDocument> pair in _project_sources) {
+            var doc = new TextDocument.clone (code_context, pair.value);
+            new_project_sources[pair.key] = doc;
             code_context.add_source_file (doc);
-            // clear all using directives (to avoid "T ambiguous with T" errors)
-            doc.current_using_directives.clear ();
             // add default using directives for the profile
             if (_profile == Vala.Profile.POSIX) {
                 // import the Posix namespace by default (namespace of backend-specific standard library)
@@ -304,35 +305,17 @@ class Vls.Compilation : BuildTarget {
                 doc.add_using_directive (ns_ref);
                 code_context.root.add_using_directive (ns_ref);
             }
-
-            // clear all comments from file
-            doc.get_comments ().clear ();
-
-            // clear all code nodes from file
-            doc.get_nodes ().clear ();
-
-            cancellable.set_error_if_cancelled ();
         }
 
         // packages (should come after in case we've wrapped any package files in TextDocuments)
         foreach (string package in _packages)
             code_context.add_external_package (package);
 
-        Vala.CodeContext.pop ();
-    }
-
-    private void compile () throws Error {
-        debug ("compiling %s ...", id);
-        Vala.CodeContext.push (code_context);
-        var vala_parser = new Vala.Parser ();
-        var genie_parser = new Vala.Genie.Parser ();
-        var gir_parser = new Vala.GirParser ();
-
         // add all generated files before compiling
         foreach (File generated_file in _generated_sources) {
             // generated files are also part of the project, so we use TextDocument intead of Vala.SourceFile
             try {
-                if (!generated_file.query_exists ())
+                if (!generated_file.query_exists (cancellable))
                     throw new FileError.NOENT (@"file does not exist");
                 code_context.add_source_file (new TextDocument (code_context, generated_file));
             } catch (Error e) {
@@ -343,11 +326,32 @@ class Vls.Compilation : BuildTarget {
             }
         }
 
-        // compile everything
-        vala_parser.parse (code_context);
-        genie_parser.parse (code_context);
-        gir_parser.parse (code_context);
-        code_context.check ();
+        Vala.CodeContext.pop();
+
+        // compile everything, suspend while we wait
+        yield Scheduler.run_async<void> (() => {
+            Vala.CodeContext.push (code_context);
+
+            var vala_parser = new Vala.Parser ();
+            var genie_parser = new Vala.Genie.Parser ();
+            var gir_parser = new Vala.GirParser ();
+
+            vala_parser.parse (code_context);
+            genie_parser.parse (code_context);
+            gir_parser.parse (code_context);
+            code_context.check ();
+
+            Vala.CodeContext.pop ();
+        }, cancellable);
+
+        // we're done. update the code context in the main thread
+        // XXX: check for any potential problems here
+        var old_project_sources = this._project_sources;
+        var old_context = this.code_context;
+        this._project_sources = new_project_sources;
+        this.code_context = code_context;
+
+        Vala.CodeContext.push (code_context);
 
         // generate output files
         // generate VAPI
@@ -378,16 +382,28 @@ class Vls.Compilation : BuildTarget {
                 source_file.accept (new CNameMapper (cname_to_sym));
         }
 
-        // remove analyses for sources that are no longer a part of the code context
-        var removed_sources = new Vala.HashSet<Vala.SourceFile> ();
-        removed_sources.add_all (code_context.get_source_files ());
-        foreach (var entry in _project_sources) {
-            var text_document = entry.value;
-            text_document.last_fresh_content = text_document.content;
-            removed_sources.remove (entry.value);
+        // clear all analyses
+        _source_analyzers.clear ();
+
+        // update the new text documents
+        foreach (Map.Entry<File, TextDocument> pair in _project_sources) {
+            var text_document = pair.value;
+            var old_text_document = old_project_sources[pair.key];
+            // confirm the change to last_compiled_content
+            text_document.last_compiled_content = text_document.content;
+            // also copy old text document metadata that may have been modified during async compilation
+            text_document.content = old_text_document.content;
+            text_document.version = old_text_document.version;
+            text_document.last_updated = old_text_document.last_updated;
+            text_document.last_saved_content = old_text_document.last_saved_content;
         }
-        foreach (var source in removed_sources)
-            _source_analyzers.unset (source, null);
+
+        // free up memory used by the old files
+        foreach (var source_file in old_context.get_source_files ()) {
+            source_file.current_using_directives.clear ();
+            source_file.get_comments ().clear ();
+            source_file.get_nodes ().clear ();
+        }
 
         last_updated = new DateTime.now ();
         _completed_first_compile = true;
@@ -410,10 +426,7 @@ class Vls.Compilation : BuildTarget {
             }
         }
         if (stale || !_completed_first_compile) {
-            configure (cancellable);
-            cancellable.set_error_if_cancelled ();
-            // TODO: cancellable compilation
-            compile ();
+            yield compile_async (cancellable);
         }
     }
 

--- a/src/projects/compilation.vala
+++ b/src/projects/compilation.vala
@@ -405,6 +405,10 @@ class Vls.Compilation : BuildTarget {
             source_file.get_nodes ().clear ();
         }
 
+        old_context.get_c_source_files ().clear ();
+        old_context.get_source_files ().clear ();
+        old_context.get_packages ().clear ();
+
         last_updated = new DateTime.now ();
         _completed_first_compile = true;
         Vala.CodeContext.pop ();

--- a/src/projects/defaultproject.vala
+++ b/src/projects/defaultproject.vala
@@ -26,12 +26,16 @@ class Vls.DefaultProject : Project {
         base (root_path);
     }
 
-    public override bool reconfigure_if_stale (Cancellable? cancellable = null) throws Error {
+    public override async bool reconfigure_async (Cancellable? cancellable = null) throws Error {
         // this should do nothing, since we don't have a backend
         return false;
     }
 
-    public override ArrayList<Pair<Vala.SourceFile, Compilation>> open (string escaped_uri, string? content = null, Cancellable? cancellable = null) throws Error {
+    public override async ArrayList<Pair<Vala.SourceFile, Compilation>> open (
+        string escaped_uri,
+        string? content = null,
+        Cancellable? cancellable = null
+    ) throws Error {
         // create a new compilation
         var file = File.new_for_uri (Uri.unescape_string (escaped_uri));
         Compilation btarget;
@@ -58,7 +62,7 @@ class Vls.DefaultProject : Project {
         // build it now so that information is available immediately on
         // file open (other projects compile on LSP initialize(), so they don't
         // need to do this)
-        btarget.build_if_stale (cancellable);
+        yield btarget.rebuild_async (cancellable);
         // make sure this comes after, that way btarget only gets added
         // if the build succeeds
         build_targets.add (btarget);

--- a/src/projects/mesonproject.vala
+++ b/src/projects/mesonproject.vala
@@ -223,7 +223,7 @@ class Vls.MesonProject : Project {
         }
     }
 
-    public override bool reconfigure_if_stale (Cancellable? cancellable = null) throws Error {
+    public override async bool reconfigure_async (Cancellable? cancellable = null) throws Error {
         if (!build_files_have_changed) {
             return false;
         }
@@ -533,17 +533,17 @@ class Vls.MesonProject : Project {
                     executes_generated_program = true;
                 }
 
-                var added_task = new BuildTask (build_dir,
-                                                target_private_output_dir,
-                                                meson_target_info.name,
-                                                meson_target_info.id,
-                                                elem_idx + (swap_with_previous_target ? -1 : 0),
-                                                first_source.compiler,
-                                                first_source.parameters,
-                                                first_source.sources,
-                                                first_source.generated_sources,
-                                                meson_target_info.filename,
-                                                first_source.language);
+                var added_task = yield new BuildTask (build_dir,
+                                                      target_private_output_dir,
+                                                      meson_target_info.name,
+                                                      meson_target_info.id,
+                                                      elem_idx + (swap_with_previous_target ? -1 : 0),
+                                                      first_source.compiler,
+                                                      first_source.parameters,
+                                                      first_source.sources,
+                                                      first_source.generated_sources,
+                                                      meson_target_info.filename,
+                                                      first_source.language);
                 build_targets.add (added_task);
                 if (previous_target != null) {
                     previous_target.no = elem_idx;
@@ -726,7 +726,7 @@ class Vls.MesonProject : Project {
         return true;
     }
 
-    public override void build_if_stale (GLib.Cancellable? cancellable = null) throws Error {
+    public override async void rebuild_async (GLib.Cancellable? cancellable = null) throws Error {
         if (requires_general_build) {
             int proc_status;
             string proc_stdout, proc_stderr;
@@ -747,13 +747,13 @@ class Vls.MesonProject : Project {
             }
         }
 
-        base.build_if_stale (cancellable);
+        yield base.rebuild_async (cancellable);
     }
 
-    public MesonProject (string root_path, Cancellable? cancellable = null) throws Error {
+    public async MesonProject (string root_path, Cancellable? cancellable = null) throws Error {
         base (root_path);
         this.build_dir = DirUtils.make_tmp (@"vls-meson-$(str_hash (root_path))-XXXXXX");
-        reconfigure_if_stale (cancellable);
+        yield reconfigure_async (cancellable);
     }
 
     ~MesonProject () {

--- a/src/projects/project.vala
+++ b/src/projects/project.vala
@@ -254,15 +254,15 @@ abstract class Vls.Project : Object {
      * Reconfigure the project if there were changes to the build files that warrant doing so.
      * Returns true if the project was actually reconfigured, false otherwise.
      */
-    public abstract bool reconfigure_if_stale (Cancellable? cancellable = null) throws Error;
+    public abstract async bool reconfigure_async (Cancellable? cancellable = null) throws Error;
 
     /**
      * Build those elements of the project that need to be rebuilt.
      */
-    public virtual void build_if_stale (Cancellable? cancellable = null) throws Error {
+    public virtual async void rebuild_async (Cancellable? cancellable = null) throws Error {
         // this iteration should be in topological order
         foreach (var btarget in build_targets)
-            btarget.build_if_stale (cancellable);
+            yield btarget.rebuild_async (cancellable);
     }
 
     /**
@@ -303,7 +303,11 @@ abstract class Vls.Project : Object {
      * Open the file. Is guaranteed to return a non-empty result, or will
      * throw an error.
      */
-    public virtual ArrayList<Pair<Vala.SourceFile, Compilation>> open (string escaped_uri, string? content = null, Cancellable? cancellable = null) throws Error {
+    public virtual async ArrayList<Pair<Vala.SourceFile, Compilation>> open (
+        string escaped_uri,
+        string? content = null,
+        Cancellable? cancellable = null
+    ) throws Error {
         var results = lookup_compile_input_source_file (escaped_uri);
         if (results.is_empty)
             throw new ProjectError.NOT_FOUND ("cannot open %s - file cannot be created for this type of project", escaped_uri);

--- a/src/projects/textdocument.vala
+++ b/src/projects/textdocument.vala
@@ -26,6 +26,9 @@ class Vls.TextDocument : SourceFile {
     public DateTime last_updated { get; set; default = new DateTime.now (); }
     public int version { get; set; }
 
+    /**
+     * Used along with {@link last_saved_content} for checkpoint and restore.
+     */
     public int last_saved_version { get; private set; }
     private string? _last_saved_content = null;
     public string last_saved_content {
@@ -40,19 +43,20 @@ class Vls.TextDocument : SourceFile {
         }
     }
 
-    private string? _last_fresh_content = null;
+    private string? _last_compiled_content = null;
 
     /**
-     * The contents at the time of compilation.
+     * The contents at the last time the code context was compiled, that is,
+     * before any intermediate modifications.
      */
-    public string last_fresh_content {
+    public string last_compiled_content {
         get {
-            if (_last_fresh_content == null)
+            if (_last_compiled_content == null)
                 return this.content;
-            return _last_fresh_content;
+            return _last_compiled_content;
         }
         set {
-            _last_fresh_content = value;
+            _last_compiled_content = value;
         }
     }
 
@@ -77,5 +81,14 @@ class Vls.TextDocument : SourceFile {
         // prefer paths to URIs, unless we don't have a path
         // (this happens when we have just opened a new file in some editors)
         base (context, ftype, path ?? uri, cont, cmdline);
+    }
+
+    public TextDocument.clone (CodeContext context, TextDocument document) {
+        base (context, document.file_type, document.filename, document.content, document.from_commandline);
+        this.last_updated = document.last_updated;
+        this.version = document.version;
+        this.last_saved_version = document.last_saved_version;
+        this._last_saved_content = document._last_saved_content;
+        this._last_compiled_content = document._last_compiled_content;
     }
 }

--- a/src/scheduler.vala
+++ b/src/scheduler.vala
@@ -1,0 +1,59 @@
+/**
+ * A task scheduler
+ */
+namespace Vls.Scheduler {
+    public delegate T TaskFunc<T> () throws Error;
+
+    class Worker<T> {
+        private TaskFunc<T> func;
+        public SourceFunc callback;
+        public Cancellable? cancellable;
+        public T? result;
+        public Error? error;
+
+        public Worker (owned TaskFunc<T> func, owned SourceFunc callback, Cancellable? cancellable = null) {
+            this.func = (owned) func;
+            this.callback = (owned) callback;
+            this.cancellable = cancellable;
+        }
+
+        public void run () {
+            try {
+                this.cancellable.set_error_if_cancelled ();
+                this.result = func ();
+            } catch (Error e) {
+                this.error = e;
+            }
+
+            Idle.add ((owned) this.callback);
+        }
+    }
+
+    private ThreadPool<Worker>? thread_pool;
+
+    /**
+     * Schedules a new task to be run on a separate thread.
+     */
+    public async T run_async<T> (owned TaskFunc<T> func, Cancellable? cancellable = null) throws Error {
+        if (thread_pool == null) {  // TODO: use GLib.Once<T>
+            thread_pool = new ThreadPool<Worker>.with_owned_data (
+                worker => worker.run (),
+                (int) get_num_processors (),
+                false
+            );
+        }
+        
+        SourceFunc callback = run_async.callback;
+        var worker = new Worker<T> ((owned) func, (owned) callback, cancellable);
+        thread_pool.add (worker);
+
+        // suspend function and come back to it when the callback is invoked (when
+        // the work is finished)
+        yield;
+
+        if (worker.error != null)
+            throw worker.error;
+
+        return worker.result;
+    }
+}

--- a/src/scheduler.vala
+++ b/src/scheduler.vala
@@ -41,6 +41,7 @@ namespace Vls.Scheduler {
                 (int) get_num_processors (),
                 false
             );
+            debug ("created a thread pool for tasks");
         }
         
         SourceFunc callback = run_async.callback;

--- a/src/server.vala
+++ b/src/server.vala
@@ -976,13 +976,6 @@ class Vls.Server : Jsonrpc.Server {
             return;
         }
 
-        try {
-            yield wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield reply_null_async (id, client, method);
-            return;
-        }
-
         // ignore multiple results
         Vala.SourceFile file = results[0].first;
         Compilation compilation = results[0].second;
@@ -1671,13 +1664,6 @@ class Vls.Server : Jsonrpc.Server {
 
     async void workspace_symbol_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var query = (string) @params.lookup_value ("query", VariantType.STRING);
-
-        try {
-            yield wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield reply_null_async (id, client, method);
-            return;
-        }
 
         var json_array = new Json.Array ();
         Project[] all_projects = projects.get_keys_as_array ();

--- a/src/server.vala
+++ b/src/server.vala
@@ -20,13 +20,10 @@
 using Lsp;
 using Gee;
 
-class Vls.Server : Object {
+class Vls.Server : Jsonrpc.Server {
     private static bool received_signal = false;
-    Jsonrpc.Server server;
     MainLoop loop;
 
-    HashTable<string, NotificationHandler> notif_handlers;
-    HashTable<string, CallHandler> call_handlers;
     InitializeParams init_params;
 
     const uint check_update_context_period_ms = 100;
@@ -52,7 +49,7 @@ class Vls.Server : Object {
     delegate void NotificationHandler (Vls.Server self, Jsonrpc.Client client, Variant @params);
 
     [CCode (has_target = false)]
-    delegate void CallHandler (Vls.Server self, Jsonrpc.Server server, Jsonrpc.Client client, string method, Variant id, Variant @params);
+    delegate void CallHandler (Vls.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params);
 
     uint[] g_sources = {};
     ulong client_closed_event_id;
@@ -82,7 +79,6 @@ class Vls.Server : Object {
 
     public Server (MainLoop loop) {
         this.loop = loop;
-        this.server = new Jsonrpc.Server ();
 
         // hack to prevent other things from corrupting JSON-RPC pipe:
         // create a new handle to stdout, and close the old one (or move it to stderr)
@@ -126,68 +122,116 @@ class Vls.Server : Object {
             return !this.shutting_down;
         });
 
-        server.accept_io_stream (new SimpleIOStream (input_stream, output_stream));
+        accept_io_stream (new SimpleIOStream (input_stream, output_stream));
 
 #if WITH_JSONRPC_GLIB_3_30
-        client_closed_event_id = server.client_closed.connect (client => {
+        client_closed_event_id = client_closed.connect (client => {
             shutdown_real ();
         });
 #endif
 
-        notif_handlers = new HashTable<string, NotificationHandler> (str_hash, str_equal);
-        call_handlers = new HashTable<string, CallHandler> (str_hash, str_equal);
-
         pending_requests = new HashSet<Request> (Request.hash, Request.equal);
 
-        server.notification.connect ((client, method, @params) => {
-            // debug (@"Got notification! $method");
-            if (notif_handlers.contains (method))
-                ((NotificationHandler) notif_handlers[method]) (this, client, @params);
-            else
-                warning (@"no notification handler for $method");
-        });
-
-        server.handle_call.connect ((client, method, id, @params) => {
-            // debug (@"Got call! $method");
-            if (call_handlers.contains (method)) {
-                ((CallHandler) call_handlers[method]) (this, server, client, method, id, @params);
-                return true;
-            } else {
-                warning (@"no call handler for $method");
-                return false;
-            }
-        });
-
         this.projects = new HashTable<Project, ulong> (GLib.direct_hash, GLib.direct_equal);
-
-        call_handlers["initialize"] = this.initialize;
-        call_handlers["shutdown"] = this.shutdown;
-        notif_handlers["exit"] = this.exit;
-
-        call_handlers["textDocument/definition"] = this.textDocumentDefinition;
-        notif_handlers["textDocument/didOpen"] = this.textDocumentDidOpen;
-        notif_handlers["textDocument/didSave"] = this.textDocumentDidSave;
-        notif_handlers["textDocument/didClose"] = this.textDocumentDidClose;
-        notif_handlers["textDocument/didChange"] = this.textDocumentDidChange;
-        call_handlers["textDocument/documentSymbol"] = this.textDocumentDocumentSymbol;
-        call_handlers["textDocument/completion"] = this.textDocumentCompletion;
-        call_handlers["textDocument/signatureHelp"] = this.textDocumentSignatureHelp;
-        call_handlers["textDocument/hover"] = this.textDocumentHover;
-        call_handlers["textDocument/formatting"] = this.textDocumentFormatting;
-        call_handlers["textDocument/references"] = this.textDocumentReferences;
-        call_handlers["textDocument/documentHighlight"] = this.textDocumentReferences;
-        call_handlers["textDocument/implementation"] = this.textDocumentImplementation;
-        call_handlers["workspace/symbol"] = this.handle_workspace_symbol_request;
-        call_handlers["textDocument/rename"] = this.textDocumentRename;
-        call_handlers["textDocument/prepareRename"] = this.textDocumentPrepareRename;
-        call_handlers["textDocument/codeLens"] = this.handle_code_lens_request;
-        notif_handlers["$/cancelRequest"] = this.cancelRequest;
 
         debug ("Finished constructing");
     }
 
+    public override bool handle_call (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+        switch (method) {
+            case "initialize":
+                initialize (client, method, id, @params);
+                return true;
+
+            case "shutdown":
+                shutdown (client, method, id, @params);
+                return true;
+
+            case "textDocument/definition":
+                text_document_definition (client, method, id, @params);
+                return true;
+
+            case "textDocument/documentSymbol":
+                text_document_document_symbol (client, method, id, @params);
+                return true;
+
+            case "textDocument/completion":
+                text_document_completion (client, method, id, @params);
+                return true;
+
+            case "textDocument/hover":
+                text_document_hover (client, method, id, @params);
+                return true;
+
+            case "textDocument/references":
+            case "textDocument/documentHighlight":
+                text_document_references (client, method, id, @params);
+                return true;
+
+            case "textDocument/signatureHelp":
+                text_document_signature_help (client, method, id, @params);
+                return true;
+
+            case "textDocument/implementation":
+                text_document_implementation (client, method, id, @params);
+                return true;
+
+            case "textDocument/rename":
+                text_document_rename (client, method, id, @params);
+                return true;
+
+            case "textDocument/prepareRename":
+                text_document_prepare_rename (client, method, id, @params);
+                return true;
+
+            case "textDocument/codeLens":
+                text_document_code_lens (client, method, id, @params);
+                return true;
+
+            case "textDocument/formatting":
+                text_document_formatting (client, method, id, @params);
+                return true;
+
+            case "workspace/symbol":
+                workspace_symbol (client, method, id, @params);
+                return true;
+        }
+        warning ("no call handler for %s", method);
+        return false;
+    }
+
+    public override void notification (Jsonrpc.Client client, string method, Variant @params) {
+        switch (method) {
+            case "exit":
+                this.exit (client, @params);
+                return;
+
+            case "textDocument/didOpen":
+                text_document_did_open (client, @params);
+                return;
+
+            case "textDocument/didSave":
+                text_document_did_save (client, @params);
+                return;
+
+            case "textDocument/didClose":
+                text_document_did_close (client, @params);
+                return;
+
+            case "textDocument/didChange":
+                text_document_did_change (client, @params);
+                return;
+
+            case "$/cancelRequest":
+                cancel_request (client, @params);
+                return;
+        }
+
+        warning ("unhandled notification %s", method);
+    }
+
     // a{sv} only
-    public Variant buildDict (...) {
+    public Variant build_dict (...) {
         var builder = new VariantBuilder (new VariantType ("a{sv}"));
         var l = va_list ();
         while (true) {
@@ -201,11 +245,11 @@ class Vls.Server : Object {
         return builder.end ();
     }
 
-    void showMessage (Jsonrpc.Client client, string message, MessageType type) {
+    void show_message (Jsonrpc.Client client, string message, MessageType type) {
         if (type == MessageType.Error)
             warning (message);
         try {
-            client.send_notification ("window/showMessage", buildDict (
+            client.send_notification ("window/showMessage", build_dict (
                 type: new Variant.int16 (type),
                 message: new Variant.string (message)
             ), cancellable);
@@ -214,7 +258,7 @@ class Vls.Server : Object {
         }
     }
 
-    void initialize (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void initialize (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         init_params = Util.parse_variant<InitializeParams> (@params);
 
         File root_dir;
@@ -225,7 +269,7 @@ class Vls.Server : Object {
         else
             root_dir = File.new_for_path (Environment.get_current_dir ());
         if (!root_dir.is_native ()) {
-            showMessage (client, "Non-native files not supported", MessageType.Error);
+            show_message (client, "Non-native files not supported", MessageType.Error);
             error ("Non-native files not supported");
         }
         string root_path = Util.realpath ((!) root_dir.get_path ());
@@ -233,15 +277,15 @@ class Vls.Server : Object {
 
         // respond
         try {
-            client.reply (id, buildDict (
-                capabilities: buildDict (
+            client.reply (id, build_dict (
+                capabilities: build_dict (
                     textDocumentSync: new Variant.int16 (TextDocumentSyncKind.Incremental),
                     definitionProvider: new Variant.boolean (true),
                     documentSymbolProvider: new Variant.boolean (true),
-                    completionProvider: buildDict(
+                    completionProvider: build_dict(
                         triggerCharacters: new Variant.strv (new string[] {".", ">"})
                     ),
-                    signatureHelpProvider: buildDict(
+                    signatureHelpProvider: build_dict(
                         triggerCharacters: new Variant.strv (new string[] {"(", "[", ","})
                     ),
                     hoverProvider: new Variant.boolean (true),
@@ -250,10 +294,10 @@ class Vls.Server : Object {
                     documentFormattingProvider: new Variant.boolean (true),
                     implementationProvider: new Variant.boolean (true),
                     workspaceSymbolProvider: new Variant.boolean (true),
-                    renameProvider: buildDict (prepareProvider: new Variant.boolean (true)),
-                    codeLensProvider: buildDict (resolveProvider: new Variant.boolean (false))
+                    renameProvider: build_dict (prepareProvider: new Variant.boolean (true)),
+                    codeLensProvider: build_dict (resolveProvider: new Variant.boolean (false))
                 ),
-                serverInfo: buildDict (
+                serverInfo: build_dict (
                     name: new Variant.string ("Vala Language Server"),
                     version: new Variant.string (Config.PROJECT_VERSION)
                 )
@@ -278,7 +322,7 @@ class Vls.Server : Object {
                 backend_project = new MesonProject (root_path, cancellable);
             } catch (Error e) {
                 if (!(e is ProjectError.VERSION_UNSUPPORTED)) {
-                    showMessage (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
+                    show_message (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
                 }
             }
         }
@@ -304,9 +348,9 @@ class Vls.Server : Object {
             var autogen_sh = root_dir.get_child ("autogen.sh");
 
             if (cmake_file.query_exists (cancellable))
-                showMessage (client, @"CMake build system is not currently supported. Only Meson is. See https://github.com/benwaffle/vala-language-server/issues/73", MessageType.Warning);
+                show_message (client, @"CMake build system is not currently supported. Only Meson is. See https://github.com/benwaffle/vala-language-server/issues/73", MessageType.Warning);
             if (autogen_sh.query_exists (cancellable))
-                showMessage (client, @"Autotools build system is not currently supported. Consider switching to Meson.", MessageType.Warning);
+                show_message (client, @"Autotools build system is not currently supported. Consider switching to Meson.", MessageType.Warning);
         } else {
             new_projects.add (backend_project);
         }
@@ -321,9 +365,9 @@ class Vls.Server : Object {
                 project.build_if_stale ();
                 debug ("Publishing diagnostics ...");
                 foreach (var compilation in project.get_compilations ())
-                    publishDiagnostics (project, compilation, client);
+                    publish_diagnostics (project, compilation, client);
             } catch (Error e) {
-                showMessage (client, @"Failed to build project - $(e.message)", MessageType.Error);
+                show_message (client, @"Failed to build project - $(e.message)", MessageType.Error);
             }
         }
 
@@ -353,7 +397,7 @@ class Vls.Server : Object {
         debug ("requested context update for project change event");
     }
 
-    void cancelRequest (Jsonrpc.Client client, Variant @params) {
+    void cancel_request (Jsonrpc.Client client, Variant @params) {
         Variant? id = @params.lookup_value ("id", null);
         if (id == null)
             return;
@@ -374,7 +418,7 @@ class Vls.Server : Object {
         }
     }
 
-    void textDocumentDidOpen (Jsonrpc.Client client, Variant @params) {
+    void text_document_did_open (Jsonrpc.Client client, Variant @params) {
         var document = @params.lookup_value ("textDocument", VariantType.VARDICT);
 
         string? uri         = (string) document.lookup_value ("uri",        VariantType.STRING);
@@ -446,7 +490,7 @@ class Vls.Server : Object {
         open_files.add (uri);
     }
 
-    void textDocumentDidSave (Jsonrpc.Client client, Variant @params) {
+    void text_document_did_save (Jsonrpc.Client client, Variant @params) {
         var document = @params.lookup_value ("textDocument", VariantType.VARDICT);
 
         string? uri = (string) document.lookup_value ("uri", VariantType.STRING);
@@ -474,7 +518,7 @@ class Vls.Server : Object {
         }
     }
 
-    void textDocumentDidClose (Jsonrpc.Client client, Variant @params) {
+    void text_document_did_close (Jsonrpc.Client client, Variant @params) {
         var document = @params.lookup_value ("textDocument", VariantType.VARDICT);
         string? uri         = (string) document.lookup_value ("uri",        VariantType.STRING);
 
@@ -505,7 +549,7 @@ class Vls.Server : Object {
     int64 update_context_requests = 0;
     int64 update_context_time_us = 0;
 
-    void textDocumentDidChange (Jsonrpc.Client client, Variant @params) {
+    void text_document_did_change (Jsonrpc.Client client, Variant @params) {
         var document = @params.lookup_value ("textDocument", VariantType.VARDICT);
         var changes = @params.lookup_value ("contentChanges", VariantType.ARRAY);
 
@@ -622,10 +666,10 @@ class Vls.Server : Object {
                         * one of our JSON-RPC callbacks through g_main_context_iteration (),
                         * if we get a new message while sending the textDocument/publishDiagnostics
                         * notifications. */
-                        publishDiagnostics (project, compilation, update_context_client);
+                        publish_diagnostics (project, compilation, update_context_client);
                 } catch (Error e) {
                     warning ("Failed to rebuild and/or reconfigure project: %s", e.message);
-                    showMessage (update_context_client, @"Failed to rebuild/reconfigure project: $(e.message)", MessageType.Error);
+                    show_message (update_context_client, @"Failed to rebuild/reconfigure project: $(e.message)", MessageType.Error);
                 }
             }
 
@@ -650,14 +694,14 @@ class Vls.Server : Object {
                             doc.get_mapped_contents ();
                         if (doc is TextDocument)
                             ((TextDocument)doc).last_saved_content = doc.content;
-                        publishDiagnostics (default_project, opened.second, update_context_client);
+                        publish_diagnostics (default_project, opened.second, update_context_client);
                     } catch (Error e) {
                         warning ("Failed to reopen in default project %s - %s", uri, e.message);
                         // clear the diagnostics for the file
                         try {
                             update_context_client.send_notification (
                                 "textDocument/publishDiagnostics",
-                                buildDict (
+                                build_dict (
                                     uri: new Variant.string (uri),
                                     diagnostics: new Variant.array (VariantType.VARIANT, {})
                                 )
@@ -721,7 +765,7 @@ class Vls.Server : Object {
         }
     }
 
-    void publishDiagnostics (Project project, Compilation target, Jsonrpc.Client client) {
+    void publish_diagnostics (Project project, Compilation target, Jsonrpc.Client client) {
         var diags_without_source = new Json.Array ();
 
         debug ("publishing diagnostics for Compilation target %s", target.id);
@@ -781,7 +825,7 @@ class Vls.Server : Object {
             try {
                 client.send_notification (
                     "textDocument/publishDiagnostics",
-                    buildDict (
+                    build_dict (
                         uri: new Variant.string (discarded_uri),
                         diagnostics: new Variant.array (VariantType.VARIANT, {})
                     )
@@ -814,7 +858,7 @@ class Vls.Server : Object {
             try {
                 client.send_notification (
                     "textDocument/publishDiagnostics",
-                    buildDict (
+                    build_dict (
                         uri: new Variant.string (gfile.get_uri ()),
                         diagnostics: diags_variant_array
                     ),
@@ -830,7 +874,7 @@ class Vls.Server : Object {
                 null);
             client.send_notification (
                 "textDocument/publishDiagnostics",
-                buildDict (
+                build_dict (
                     // use the project root as the URI if the diagnostic is not associated with a file
                     uri: new Variant.string (File.new_for_path(project.root_path).get_uri ()),
                     diagnostics: diags_wo_src_variant_array
@@ -879,7 +923,7 @@ class Vls.Server : Object {
         return (!) best;
     }
 
-    void textDocumentDefinition (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_definition (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams> (@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -977,7 +1021,7 @@ class Vls.Server : Object {
         });
     }
 
-    void textDocumentDocumentSymbol (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_document_symbol (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1096,7 +1140,7 @@ class Vls.Server : Object {
         return doc_comment;
     }
 
-    void textDocumentCompletion (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_completion (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.CompletionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1124,7 +1168,7 @@ class Vls.Server : Object {
                                          p.position, p.context);
     }
 
-    void textDocumentSignatureHelp (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_signature_help (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1152,7 +1196,7 @@ class Vls.Server : Object {
                                             p.position);
     }
 
-    void textDocumentHover (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_hover (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1353,7 +1397,7 @@ class Vls.Server : Object {
         return DocumentHighlightKind.Text;
     }
 
-    void textDocumentReferences (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_references (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<ReferenceParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1465,7 +1509,7 @@ class Vls.Server : Object {
         });
     }
 
-    void textDocumentImplementation (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_implementation (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1584,7 +1628,7 @@ class Vls.Server : Object {
         });
     }
     
-    void textDocumentFormatting (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_formatting (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.DocumentFormattingParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1632,7 +1676,7 @@ class Vls.Server : Object {
         }
     }
 
-    void handle_workspace_symbol_request (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void workspace_symbol (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var query = (string) @params.lookup_value ("query", VariantType.STRING);
 
         wait_for_context_update (id, request_cancelled => {
@@ -1675,7 +1719,7 @@ class Vls.Server : Object {
         });
     }
 
-    void textDocumentRename (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_rename (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         string new_name = (string) @params.lookup_value ("newName", VariantType.STRING);
 
         // before anything, sanity-check the new symbol name
@@ -1830,7 +1874,7 @@ class Vls.Server : Object {
                 Variant changes = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (text_document_edits_json), null);
                 client.reply (
                     id, 
-                    buildDict (
+                    build_dict (
                         documentChanges: changes
                     ),
                     cancellable);
@@ -1842,7 +1886,7 @@ class Vls.Server : Object {
         });
     }
     
-    void textDocumentPrepareRename (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_prepare_rename (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<TextDocumentPositionParams> (@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1945,7 +1989,7 @@ class Vls.Server : Object {
             try {
                 client.reply (
                     id,
-                    buildDict (
+                    build_dict (
                         range: Util.object_to_variant (replacement_range),
                         placeholder: new Variant.string (symbol.name)
                     ),
@@ -1960,7 +2004,7 @@ class Vls.Server : Object {
     /**
      * handle an incoming `textDocument/codeLens` request
      */
-    void handle_code_lens_request (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void text_document_code_lens (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var document = @params.lookup_value ("textDocument", VariantType.VARDICT);
         string? uri = document != null ? (string?) document.lookup_value ("uri", VariantType.STRING) : null;
 
@@ -1995,7 +2039,7 @@ class Vls.Server : Object {
                                        results[0].first, results[0].second);
     }
 
-    void shutdown (Jsonrpc.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    void shutdown (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         reply_null (id, client, "shutdown");
         shutdown_real ();
     }
@@ -2009,7 +2053,7 @@ class Vls.Server : Object {
         this.shutting_down = true;
         cancellable.cancel ();
         if (client_closed_event_id != 0)
-            server.disconnect (client_closed_event_id);
+            this.disconnect (client_closed_event_id);
         foreach (var project in projects.get_keys_as_array ())
             project.disconnect (projects[project]);
         loop.quit ();

--- a/src/server.vala
+++ b/src/server.vala
@@ -1988,7 +1988,6 @@ class Vls.Server : Jsonrpc.Server {
             if (!(btarget_w_sym.second.source_reference.file is TextDocument)) {
                 // This means we have found references in a file that was added automatically,
                 // which should not be modified.
-                // TODO: rewrite all code to use async
                 string? pkg = btarget_w_sym.second.source_reference.file.package_name;
                 Vala.CodeContext.pop ();
                 try {

--- a/src/server.vala
+++ b/src/server.vala
@@ -1053,14 +1053,6 @@ class Vls.Server : Jsonrpc.Server {
 
     async void text_document_document_symbol_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
-
-        try {
-            yield wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield reply_null_async (id, client, method);
-            return;
-        }
-
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
         foreach (var project in projects.get_keys_as_array ()) {
@@ -1239,13 +1231,6 @@ class Vls.Server : Jsonrpc.Server {
         }
 
         Position pos = p.position;
-        try {
-            yield wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield reply_null_async (id, client, method);
-            return;
-        }
-
         Vala.SourceFile doc = results[0].first;
         Compilation compilation = results[0].second;
         Vala.CodeContext.push (compilation.code_context);
@@ -1419,13 +1404,6 @@ class Vls.Server : Jsonrpc.Server {
 
     async void text_document_references_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<ReferenceParams>(@params);
-        try {
-            yield wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield reply_null_async (id, client, method);
-            return;
-        }
-
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
         foreach (var project in projects.get_keys_as_array ()) {
@@ -1751,6 +1729,14 @@ class Vls.Server : Jsonrpc.Server {
             return;
         }
 
+        // we cannot rename until everything is up-to-date
+        try {
+            yield wait_for_context_update_async (id, method);
+        } catch (Error e) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
         var p = Util.parse_variant<TextDocumentPositionParams> (@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1773,13 +1759,6 @@ class Vls.Server : Jsonrpc.Server {
         }
 
         Position pos = p.position;
-        try {
-            yield wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield reply_null_async (id, client, method);
-            return;
-        }
-
         Vala.SourceFile doc = results[0].first;
         Compilation compilation = results[0].second;
         Vala.CodeContext.push (compilation.code_context);
@@ -1906,6 +1885,14 @@ class Vls.Server : Jsonrpc.Server {
     }
     
     async void text_document_prepare_rename_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+        // we cannot think of renaming things until everything is up-to-date
+        try {
+            yield wait_for_context_update_async (id, method);
+        } catch (Error e) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
         var p = Util.parse_variant<TextDocumentPositionParams> (@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1928,13 +1915,6 @@ class Vls.Server : Jsonrpc.Server {
         }
 
         Position pos = p.position;
-        try {
-            yield wait_for_context_update_async (id, method);
-        } catch (Error e) {
-            yield reply_null_async (id, client, method);
-            return;
-        }
-
         Vala.SourceFile doc = results[0].first;
         Compilation compilation = results[0].second;
         Vala.CodeContext.push (compilation.code_context);
@@ -2048,6 +2028,13 @@ class Vls.Server : Jsonrpc.Server {
 
         if (document == null || uri == null) {
             warning ("[%s] `textDocument` or `uri` not provided as expected", method);
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
+        try {
+            yield wait_for_context_update_async (id, method);
+        } catch (Error e) {
             yield reply_null_async (id, client, method);
             return;
         }

--- a/src/server.vala
+++ b/src/server.vala
@@ -40,6 +40,8 @@ class Vls.Server : Jsonrpc.Server {
 
     bool shutting_down = false;
 
+    bool initialized = false;
+
     /**
      * The global cancellable object
      */
@@ -51,7 +53,6 @@ class Vls.Server : Jsonrpc.Server {
     [CCode (has_target = false)]
     delegate void CallHandler (Vls.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params);
 
-    uint[] g_sources = {};
     ulong client_closed_event_id;
     HashTable<Project, ulong> projects;
     DefaultProject default_project;
@@ -114,7 +115,7 @@ class Vls.Server : Jsonrpc.Server {
 #endif
 
         // shutdown if/when we get a signal
-        g_sources += Timeout.add (1 * 1000, () => {
+        Timeout.add (1 * 1000, () => {
             if (Server.received_signal) {
                 shutdown_real ();
                 return Source.REMOVE;
@@ -140,7 +141,7 @@ class Vls.Server : Jsonrpc.Server {
     public override bool handle_call (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         switch (method) {
             case "initialize":
-                initialize (client, method, id, @params);
+                initialize_async.begin (client, method, id, @params);
                 return true;
 
             case "shutdown":
@@ -148,11 +149,11 @@ class Vls.Server : Jsonrpc.Server {
                 return true;
 
             case "textDocument/definition":
-                text_document_definition (client, method, id, @params);
+                text_document_definition_async.begin (client, method, id, @params);
                 return true;
 
             case "textDocument/documentSymbol":
-                text_document_document_symbol (client, method, id, @params);
+                text_document_document_symbol_async.begin (client, method, id, @params);
                 return true;
 
             case "textDocument/completion":
@@ -160,12 +161,12 @@ class Vls.Server : Jsonrpc.Server {
                 return true;
 
             case "textDocument/hover":
-                text_document_hover (client, method, id, @params);
+                text_document_hover_async.begin (client, method, id, @params);
                 return true;
 
             case "textDocument/references":
             case "textDocument/documentHighlight":
-                text_document_references (client, method, id, @params);
+                text_document_references_async.begin (client, method, id, @params);
                 return true;
 
             case "textDocument/signatureHelp":
@@ -173,15 +174,15 @@ class Vls.Server : Jsonrpc.Server {
                 return true;
 
             case "textDocument/implementation":
-                text_document_implementation (client, method, id, @params);
+                text_document_implementation_async.begin (client, method, id, @params);
                 return true;
 
             case "textDocument/rename":
-                text_document_rename (client, method, id, @params);
+                text_document_rename_async.begin (client, method, id, @params);
                 return true;
 
             case "textDocument/prepareRename":
-                text_document_prepare_rename (client, method, id, @params);
+                text_document_prepare_rename_async.begin (client, method, id, @params);
                 return true;
 
             case "textDocument/codeLens":
@@ -193,7 +194,7 @@ class Vls.Server : Jsonrpc.Server {
                 return true;
 
             case "workspace/symbol":
-                workspace_symbol (client, method, id, @params);
+                workspace_symbol_async.begin (client, method, id, @params);
                 return true;
         }
         warning ("no call handler for %s", method);
@@ -207,7 +208,7 @@ class Vls.Server : Jsonrpc.Server {
                 return;
 
             case "textDocument/didOpen":
-                text_document_did_open (client, @params);
+                text_document_did_open_async.begin (client, @params);
                 return;
 
             case "textDocument/didSave":
@@ -245,20 +246,24 @@ class Vls.Server : Jsonrpc.Server {
         return builder.end ();
     }
 
-    void show_message (Jsonrpc.Client client, string message, MessageType type) {
+    async void show_message_async (Jsonrpc.Client client, string message, MessageType type) {
         if (type == MessageType.Error)
             warning (message);
         try {
-            client.send_notification ("window/showMessage", build_dict (
-                type: new Variant.int16 (type),
-                message: new Variant.string (message)
-            ), cancellable);
+            yield client.send_notification_async (
+                "window/showMessage",
+                    build_dict (
+                    type: new Variant.int16 (type),
+                    message: new Variant.string (message)
+                ),
+                cancellable
+            );
         } catch (Error e) {
             debug (@"showMessage: failed to notify client: $(e.message)");
         }
     }
 
-    void initialize (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void initialize_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         init_params = Util.parse_variant<InitializeParams> (@params);
 
         File root_dir;
@@ -269,15 +274,96 @@ class Vls.Server : Jsonrpc.Server {
         else
             root_dir = File.new_for_path (Environment.get_current_dir ());
         if (!root_dir.is_native ()) {
-            show_message (client, "Non-native files not supported", MessageType.Error);
+            yield show_message_async (client, "Non-native files not supported", MessageType.Error);
             error ("Non-native files not supported");
         }
         string root_path = Util.realpath ((!) root_dir.get_path ());
         debug (@"[initialize] root path is $root_path");
 
-        // respond
+        var meson_file = root_dir.get_child ("meson.build");
+        ArrayList<File> cc_files = new ArrayList<File> ();
         try {
-            client.reply (id, build_dict (
+            cc_files = Util.find_files (root_dir, /compile_commands\.json/, 2);
+        } catch (Error e) {
+            warning ("could not enumerate root dir - %s", e.message);
+        }
+
+        var new_projects = new ArrayList<Project> ();
+        Project? backend_project = null;
+        // TODO: autotools, make(?), cmake(?)
+        if (meson_file.query_exists (cancellable)) {
+            try {
+                backend_project = yield new MesonProject (root_path, cancellable);
+            } catch (Error e) {
+                if (!(e is ProjectError.VERSION_UNSUPPORTED)) {
+                    yield show_message_async (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
+                }
+            }
+        }
+        
+        // try compile_commands.json if Meson failed
+        if (backend_project == null && !cc_files.is_empty) {
+            foreach (var cc_file in cc_files) {
+                string cc_file_path = Util.realpath (cc_file.get_path ());
+                try {
+                    backend_project = yield new CcProject (root_path, cc_file_path, cancellable);
+                    debug ("[initialize] initialized CcProject with %s", cc_file_path);
+                    break;
+                } catch (Error e) {
+                    debug ("[initialize] CcProject failed with %s - %s", cc_file_path, e.message);
+                    continue;
+                }
+            }
+        }
+
+        // show messages if we could not get a backend-specific project
+        if (backend_project == null) {
+            var cmake_file = root_dir.get_child ("CMakeLists.txt");
+            var autogen_sh = root_dir.get_child ("autogen.sh");
+
+            if (cmake_file.query_exists (cancellable))
+                yield show_message_async (client, @"CMake build system is not currently supported. Only Meson is. See https://github.com/benwaffle/vala-language-server/issues/73", MessageType.Warning);
+            if (autogen_sh.query_exists (cancellable))
+                yield show_message_async (client, @"Autotools build system is not currently supported. Consider switching to Meson.", MessageType.Warning);
+        } else {
+            new_projects.add (backend_project);
+        }
+
+        // always have default project
+        default_project = new DefaultProject (root_path);
+
+        // build and publish diagnostics
+        foreach (var project in new_projects) {
+            try {
+                debug ("Building project ...");
+                yield project.rebuild_async ();
+                debug ("Publishing diagnostics ...");
+                foreach (var compilation in project.get_compilations ())
+                    yield publish_diagnostics_async (project, compilation, client);
+            } catch (Error e) {
+                yield show_message_async (client, @"Failed to build project - $(e.message)", MessageType.Error);
+            }
+        }
+
+        // create documentation (compiles GIR files too)
+        var packages = new HashSet<Vala.SourceFile> ();
+        var custom_gir_dirs = new HashSet<File> (Util.file_hash, Util.file_equal);
+        foreach (var project in new_projects) {
+            packages.add_all (project.get_packages ());
+            custom_gir_dirs.add_all (project.get_custom_gir_dirs ());
+        }
+        documentation = new GirDocumentation (packages, custom_gir_dirs);
+
+        // listen for project changed events
+        foreach (Project project in new_projects)
+            projects[project] = project.changed.connect (project_changed_event);
+
+        // listen for context update requests
+        update_context_client = client;
+
+        // Respond. Now we've "returned" from the LSP client's point of view.
+        try {
+            yield client.reply_async (id, build_dict (
                 capabilities: build_dict (
                     textDocumentSync: new Variant.int16 (TextDocumentSyncKind.Incremental),
                     definitionProvider: new Variant.boolean (true),
@@ -302,94 +388,12 @@ class Vls.Server : Jsonrpc.Server {
                     version: new Variant.string (Config.PROJECT_VERSION)
                 )
             ), cancellable);
+            initialized = true;
         } catch (Error e) {
             error (@"[initialize] failed to reply to client: $(e.message)");
         }
 
-        var meson_file = root_dir.get_child ("meson.build");
-        ArrayList<File> cc_files = new ArrayList<File> ();
-        try {
-            cc_files = Util.find_files (root_dir, /compile_commands\.json/, 2);
-        } catch (Error e) {
-            warning ("could not enumerate root dir - %s", e.message);
-        }
-
-        var new_projects = new ArrayList<Project> ();
-        Project? backend_project = null;
-        // TODO: autotools, make(?), cmake(?)
-        if (meson_file.query_exists (cancellable)) {
-            try {
-                backend_project = new MesonProject (root_path, cancellable);
-            } catch (Error e) {
-                if (!(e is ProjectError.VERSION_UNSUPPORTED)) {
-                    show_message (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
-                }
-            }
-        }
-        
-        // try compile_commands.json if Meson failed
-        if (backend_project == null && !cc_files.is_empty) {
-            foreach (var cc_file in cc_files) {
-                string cc_file_path = Util.realpath (cc_file.get_path ());
-                try {
-                    backend_project = new CcProject (root_path, cc_file_path, cancellable);
-                    debug ("[initialize] initialized CcProject with %s", cc_file_path);
-                    break;
-                } catch (Error e) {
-                    debug ("[initialize] CcProject failed with %s - %s", cc_file_path, e.message);
-                    continue;
-                }
-            }
-        }
-
-        // show messages if we could not get a backend-specific project
-        if (backend_project == null) {
-            var cmake_file = root_dir.get_child ("CMakeLists.txt");
-            var autogen_sh = root_dir.get_child ("autogen.sh");
-
-            if (cmake_file.query_exists (cancellable))
-                show_message (client, @"CMake build system is not currently supported. Only Meson is. See https://github.com/benwaffle/vala-language-server/issues/73", MessageType.Warning);
-            if (autogen_sh.query_exists (cancellable))
-                show_message (client, @"Autotools build system is not currently supported. Consider switching to Meson.", MessageType.Warning);
-        } else {
-            new_projects.add (backend_project);
-        }
-
-        // always have default project
-        default_project = new DefaultProject (root_path);
-
-        // build and publish diagnostics
-        foreach (var project in new_projects) {
-            try {
-                debug ("Building project ...");
-                project.build_if_stale ();
-                debug ("Publishing diagnostics ...");
-                foreach (var compilation in project.get_compilations ())
-                    publish_diagnostics (project, compilation, client);
-            } catch (Error e) {
-                show_message (client, @"Failed to build project - $(e.message)", MessageType.Error);
-            }
-        }
-
-        // create documentation (compiles GIR files too)
-        var packages = new HashSet<Vala.SourceFile> ();
-        var custom_gir_dirs = new HashSet<File> (Util.file_hash, Util.file_equal);
-        foreach (var project in new_projects) {
-            packages.add_all (project.get_packages ());
-            custom_gir_dirs.add_all (project.get_custom_gir_dirs ());
-        }
-        documentation = new GirDocumentation (packages, custom_gir_dirs);
-
-        // listen for context update requests
-        update_context_client = client;
-        g_sources += Timeout.add (check_update_context_period_ms, () => {
-            check_update_context ();
-            return !this.shutting_down;
-        });
-
-        // listen for project changed events
-        foreach (Project project in new_projects)
-            projects[project] = project.changed.connect (project_changed_event);
+        check_update_context_async.begin ();    // begin long-running task
     }
 
     void project_changed_event () {
@@ -418,7 +422,15 @@ class Vls.Server : Jsonrpc.Server {
         }
     }
 
-    void text_document_did_open (Jsonrpc.Client client, Variant @params) {
+    public static async void reply_null_async (Variant id, Jsonrpc.Client client, string method) {
+        try {
+            yield client.reply_async (id, new Variant.maybe (VariantType.VARIANT, null), cancellable);
+        } catch (Error e) {
+            debug (@"[$method] failed to reply to client: $(e.message)");
+        }
+    }
+
+    async void text_document_did_open_async (Jsonrpc.Client client, Variant @params) {
         var document = @params.lookup_value ("textDocument", VariantType.VARDICT);
 
         string? uri         = (string) document.lookup_value ("uri",        VariantType.STRING);
@@ -439,7 +451,7 @@ class Vls.Server : Jsonrpc.Server {
 
         foreach (var project in projects.get_keys_as_array ()) {
             try {
-                doc_w_bt = project.open (uri, fileContents, cancellable).first ();
+                doc_w_bt = (yield project.open (uri, fileContents, cancellable)).first ();
                 break;
             } catch (Error e) {
                 if (!(e is ProjectError.NOT_FOUND))
@@ -450,7 +462,7 @@ class Vls.Server : Jsonrpc.Server {
         // fallback to default project
         if (doc_w_bt == null) {
             try {
-                doc_w_bt = default_project.open (uri, fileContents, cancellable).first ();
+                doc_w_bt = (yield default_project.open (uri, fileContents, cancellable)).first ();
                 // it's possible that we opened a Vala script and have to
                 // include additional packages for documentation
                 foreach (var pkg in default_project.get_packages ())
@@ -621,109 +633,119 @@ class Vls.Server : Jsonrpc.Server {
     }
 
     /** 
-     * Reconfigure the project if needed, and check whether we need to rebuild
-     * the project and documentation engine if we have context update requests.
+     * Runs in the background periodically. Reconfigures the project if needed,
+     * and checks whether we need to rebuild the project and documentation
+     * engine if we have context update requests.
      */
-    void check_update_context () {
-        if (update_context_requests > 0 && get_monotonic_time () >= update_context_time_us) {
-            debug ("updating contexts and publishing diagnostics...");
-            update_context_requests = 0;
-            update_context_time_us = 0;
+    async void check_update_context_async () {
+        while (!shutting_down && !cancellable.is_cancelled ()) {
+            if (update_context_requests > 0 && get_monotonic_time () >= update_context_time_us) {
+                debug ("updating contexts and publishing diagnostics...");
+                update_context_requests = 0;
+                update_context_time_us = 0;
 
-            Project[] all_projects = projects.get_keys_as_array ();
-            all_projects += default_project;
-            bool reconfigured_projects = false;
-            foreach (var project in all_projects) {
-                try {
-                    bool reconfigured = project.reconfigure_if_stale (cancellable);
-                    reconfigured_projects |= reconfigured;
-                    project.build_if_stale (cancellable);
+                Project[] all_projects = projects.get_keys_as_array ();
+                all_projects += default_project;
+                bool reconfigured_projects = false;
+                foreach (var project in all_projects) {
+                    try {
+                        bool reconfigured = yield project.reconfigure_async (cancellable);
+                        reconfigured_projects |= reconfigured;
+                        yield project.rebuild_async (cancellable);
 
-                    // remove all newly-added files from the default project
-                    if (reconfigured && project != default_project) {
-                        var newly_added = new HashSet<string> ();
-                        foreach (var compilation in project.get_compilations ())
-                            newly_added.add_all_iterator (compilation.get_project_files ().map<string> (f => f.filename));
-                        foreach (var compilation in default_project.get_compilations ()) {
-                            foreach (var source_file in compilation.get_project_files ()) {
-                                if (newly_added.contains (source_file.filename)) {
-                                    var uri = File.new_for_path (source_file.filename).get_uri ();
-                                    try {
-                                        default_project.close (uri);
-                                        discarded_files.add (uri);
-                                        debug ("discarding %s from DefaultProject", uri);
-                                    } catch (Error e) {
-                                        // just ignore
+                        // remove all newly-added files from the default project
+                        if (reconfigured && project != default_project) {
+                            var newly_added = new HashSet<string> ();
+                            foreach (var compilation in project.get_compilations ())
+                                newly_added.add_all_iterator (compilation.get_project_files ().map<string> (f => f.filename));
+                            foreach (var compilation in default_project.get_compilations ()) {
+                                foreach (var source_file in compilation.get_project_files ()) {
+                                    if (newly_added.contains (source_file.filename)) {
+                                        var uri = File.new_for_path (source_file.filename).get_uri ();
+                                        try {
+                                            default_project.close (uri);
+                                            discarded_files.add (uri);
+                                            debug ("discarding %s from DefaultProject", uri);
+                                        } catch (Error e) {
+                                            // just ignore
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    foreach (var compilation in project.get_compilations ())
-                        /* This must come after the resetting of the two variables above,
-                        * since it's possible for publishDiagnostics to eventually call
-                        * one of our JSON-RPC callbacks through g_main_context_iteration (),
-                        * if we get a new message while sending the textDocument/publishDiagnostics
-                        * notifications. */
-                        publish_diagnostics (project, compilation, update_context_client);
-                } catch (Error e) {
-                    warning ("Failed to rebuild and/or reconfigure project: %s", e.message);
-                    show_message (update_context_client, @"Failed to rebuild/reconfigure project: $(e.message)", MessageType.Error);
-                }
-            }
-
-            // add open files that do not belong to any project to the default project
-            if (reconfigured_projects) {
-                var orphaned_files = new HashSet<string> ();
-                orphaned_files.add_all (open_files);
-                foreach (var project in projects.get_keys ()) {
-                    foreach (var compilation in project.get_compilations ()) {
-                        foreach (var source_file in compilation.code_context.get_source_files ()) {
-                            var uri = File.new_for_path (source_file.filename).get_uri ();
-                            orphaned_files.remove (uri);
-                        }
-                    }
-                }
-                foreach (var uri in orphaned_files) {
-                    try {
-                        var opened = default_project.open (uri, null, cancellable).first ();
-                        // ensure the file's contents are available
-                        var doc = opened.first;
-                        if (doc.content == null)
-                            doc.get_mapped_contents ();
-                        if (doc is TextDocument)
-                            ((TextDocument)doc).last_saved_content = doc.content;
-                        publish_diagnostics (default_project, opened.second, update_context_client);
+                        foreach (var compilation in project.get_compilations ())
+                            /* NOTE: This must come after the resetting of the two variables above,
+                             * since it's possible for publish_diagnostics_async() to eventually call
+                             * one of our JSON-RPC callbacks through g_main_context_iteration (),
+                             * if we get a new message while sending the textDocument/publishDiagnostics
+                             * notifications. */
+                            yield publish_diagnostics_async (project, compilation, update_context_client);
                     } catch (Error e) {
-                        warning ("Failed to reopen in default project %s - %s", uri, e.message);
-                        // clear the diagnostics for the file
+                        warning ("Failed to rebuild and/or reconfigure project: %s", e.message);
+                        yield show_message_async (update_context_client, @"Failed to rebuild/reconfigure project: $(e.message)", MessageType.Error);
+                    }
+                }
+
+                // add open files that do not belong to any project to the default project
+                if (reconfigured_projects) {
+                    var orphaned_files = new HashSet<string> ();
+                    orphaned_files.add_all (open_files);
+                    foreach (var project in projects.get_keys ()) {
+                        foreach (var compilation in project.get_compilations ()) {
+                            foreach (var source_file in compilation.code_context.get_source_files ()) {
+                                var uri = File.new_for_path (source_file.filename).get_uri ();
+                                orphaned_files.remove (uri);
+                            }
+                        }
+                    }
+                    foreach (var uri in orphaned_files) {
                         try {
-                            update_context_client.send_notification (
-                                "textDocument/publishDiagnostics",
-                                build_dict (
-                                    uri: new Variant.string (uri),
-                                    diagnostics: new Variant.array (VariantType.VARIANT, {})
-                                )
-                            );
+                            var opened = (yield default_project.open (uri, null, cancellable)).first ();
+                            // ensure the file's contents are available
+                            var doc = opened.first;
+                            if (doc.content == null)
+                                doc.get_mapped_contents ();
+                            if (doc is TextDocument)
+                                ((TextDocument)doc).last_saved_content = doc.content;
+                            yield publish_diagnostics_async (default_project, opened.second, update_context_client);
                         } catch (Error e) {
-                            warning ("Failed to clear diagnostics for %s - %s", uri, e.message);
+                            warning ("Failed to reopen in default project %s - %s", uri, e.message);
+                            // clear the diagnostics for the file
+                            try {
+                                yield update_context_client.send_notification_async (
+                                    "textDocument/publishDiagnostics",
+                                    build_dict (
+                                        uri: new Variant.string (uri),
+                                        diagnostics: new Variant.array (VariantType.VARIANT, {})
+                                    ),
+                                    cancellable
+                                );
+                            } catch (Error e) {
+                                warning ("Failed to clear diagnostics for %s - %s", uri, e.message);
+                            }
                         }
                     }
                 }
+
+                // rebuild the documentation
+                documentation.rebuild_if_stale ();
             }
 
-            // rebuild the documentation
-            documentation.rebuild_if_stale ();
+            // schedule ourselves
+            SourceFunc callback = check_update_context_async.callback;
+            Timeout.add (check_update_context_period_ms, () => {
+                callback ();
+                return Source.REMOVE;
+            });
+            yield;
         }
     }
 
     public delegate void OnContextUpdatedFunc (bool request_cancelled);
 
     /**
-     * Rather than satisfying all requests in `check_update_context ()`,
-     * to avoid race conditions, we have to spawn a timeout to check for 
-     * the right conditions to call `on_context_updated_func ()`.
+     * Runs `on_context_updated_func` after the context has updated.
      */
     public void wait_for_context_update (Variant id, owned OnContextUpdatedFunc on_context_updated_func) {
         // we've already updated the context
@@ -765,7 +787,50 @@ class Vls.Server : Jsonrpc.Server {
         }
     }
 
-    void publish_diagnostics (Project project, Compilation target, Jsonrpc.Client client) {
+    /**
+     * Returns `false` if the request was cancelled.
+     */
+    public async bool wait_for_context_update_async (Variant id, string? method = null) {
+        if (initialized && update_context_requests == 0)
+            return true;
+
+        var req = new Request (id, method);
+
+        if (!pending_requests.add (req))
+            warning (@"Request ($req): request already in pending requests, this should not happen");
+
+        bool success = false;
+        SourceFunc callback = wait_for_context_update_async.callback;
+
+        Timeout.add (wait_for_context_update_delay_ms, () => {
+            if (initialized && update_context_requests == 0) {
+                // context was updated
+                // if [req] is still present, it hasn't been cancelled
+                success = pending_requests.remove (req);
+                callback ();
+                return Source.REMOVE;
+            }
+
+            // context hasn't been updated yet
+
+            if (!pending_requests.contains (req)) {
+                // request has been cancelled before context was updated
+                success = false;
+                callback ();
+                return Source.REMOVE;
+            }
+
+            // otherwise just continue waiting...
+            debug (@"Request ($req): waiting for context update ...");
+            return Source.CONTINUE;
+        });
+
+        yield;  // wait for scheduling of background
+
+        return success;
+    }
+
+    async void publish_diagnostics_async (Project project, Compilation target, Jsonrpc.Client client) {
         var diags_without_source = new Json.Array ();
 
         debug ("publishing diagnostics for Compilation target %s", target.id);
@@ -823,12 +888,13 @@ class Vls.Server : Jsonrpc.Server {
         var discarded_files_published = new ArrayList<string> ();
         foreach (string discarded_uri in discarded_files) {
             try {
-                client.send_notification (
+                yield client.send_notification_async (
                     "textDocument/publishDiagnostics",
                     build_dict (
                         uri: new Variant.string (discarded_uri),
                         diagnostics: new Variant.array (VariantType.VARIANT, {})
-                    )
+                    ),
+                    cancellable
                 );
                 discarded_files_published.add (discarded_uri);
             } catch (Error e) {
@@ -856,13 +922,14 @@ class Vls.Server : Jsonrpc.Server {
             }
 
             try {
-                client.send_notification (
+                yield client.send_notification_async (
                     "textDocument/publishDiagnostics",
                     build_dict (
                         uri: new Variant.string (gfile.get_uri ()),
                         diagnostics: diags_variant_array
                     ),
-                    cancellable);
+                    cancellable
+                );
             } catch (Error e) {
                 warning (@"[publishDiagnostics] failed to notify client: $(e.message)");
             }
@@ -872,14 +939,15 @@ class Vls.Server : Jsonrpc.Server {
             Variant diags_wo_src_variant_array = Json.gvariant_deserialize (
                 new Json.Node.alloc ().init_array (diags_without_source),
                 null);
-            client.send_notification (
+            yield client.send_notification_async (
                 "textDocument/publishDiagnostics",
                 build_dict (
                     // use the project root as the URI if the diagnostic is not associated with a file
                     uri: new Variant.string (File.new_for_path(project.root_path).get_uri ()),
                     diagnostics: diags_wo_src_variant_array
                 ),
-                cancellable);
+                cancellable
+            );
         } catch (Error e) {
             warning (@"[publishDiagnostics] failed to publish diags without source: $(e.message)");
         }
@@ -923,7 +991,7 @@ class Vls.Server : Jsonrpc.Server {
         return (!) best;
     }
 
-    void text_document_definition (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void text_document_definition_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams> (@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -941,87 +1009,85 @@ class Vls.Server : Jsonrpc.Server {
         }
         if (results.is_empty) {
             debug (@"[$method] file `$(p.textDocument.uri)' not found");
-            reply_null (id, client, method);
+            yield reply_null_async (id, client, method);
             return;
         }
 
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, method);
-                return;
-            }
+        if (!yield wait_for_context_update_async (id)) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
 
-            // ignore multiple results
-            Vala.SourceFile file = results[0].first;
-            Compilation compilation = results[0].second;
+        // ignore multiple results
+        Vala.SourceFile file = results[0].first;
+        Compilation compilation = results[0].second;
 
-            Vala.CodeContext.push (compilation.code_context);
-            var fs = new FindSymbol (file, p.position, true);
+        Vala.CodeContext.push (compilation.code_context);
+        var fs = new FindSymbol (file, p.position, true);
 
-            if (fs.result.size == 0) {
-                debug ("[%s] find symbol is empty", method);
-                try {
-                    client.reply (id, new Variant.maybe (VariantType.VARIANT, null), cancellable);
-                } catch (Error e) {
-                    debug("[textDocument/definition] failed to reply to client: %s", e.message);
-                }
-                Vala.CodeContext.pop ();
-                return;
-            }
-
-            Vala.CodeNode? best = get_best (fs, file);
-
-            if (best is Vala.Expression && !(best is Vala.Literal)) {
-                var b = (Vala.Expression)best;
-                debug ("best (%p) is a Expression (symbol_reference = %p)", best, b.symbol_reference);
-                if (b.symbol_reference != null && b.symbol_reference.source_reference != null) {
-                    best = b.symbol_reference;
-                    debug ("best is now the symbol_referenece => %p (%s)", best, best.to_string ());
-                }
-            } else if (best is Vala.DataType) {
-                best = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) best);
-            } else if (best is Vala.UsingDirective) {
-                best = ((Vala.UsingDirective)best).namespace_symbol;
-            } else if (best is Vala.Method) {
-                var m = (Vala.Method)best;
-
-                if (m.base_interface_method != m && m.base_interface_method != null)
-                    best = m.base_interface_method;
-                else if (m.base_method != m && m.base_method != null)
-                    best = m.base_method;
-            } else if (best is Vala.Property) {
-                var prop = (Vala.Property)best;
-
-                if (prop.base_interface_property != prop && prop.base_interface_property != null)
-                    best = prop.base_interface_property;
-                else if (prop.base_property != prop && prop.base_property != null)
-                    best = prop.base_property;
-            } else {
-                debug ("[%s] best is %s, which we can't handle", method, best != null ? best.type_name : null);
-                try {
-                    client.reply (id, new Variant.maybe (VariantType.VARIANT, null), cancellable);
-                } catch (Error e) {
-                    debug("[textDocument/definition] failed to reply to client: %s", e.message);
-                }
-                Vala.CodeContext.pop ();
-                return;
-            }
-
-            if (best is Vala.Symbol)
-                best = SymbolReferences.find_real_symbol (selected_project, (Vala.Symbol) best);
-
-            var location = new Location.from_sourceref (best.source_reference);
-            debug ("[textDocument/definition] found location ... %s", location.uri);
+        if (fs.result.size == 0) {
+            debug ("[%s] find symbol is empty", method);
+            Vala.CodeContext.pop ();
             try {
-                client.reply (id, Util.object_to_variant (location), cancellable);
+                yield client.reply_async (id, new Variant.maybe (VariantType.VARIANT, null), cancellable);
             } catch (Error e) {
                 debug("[textDocument/definition] failed to reply to client: %s", e.message);
             }
+            return;
+        }
+
+        Vala.CodeNode? best = get_best (fs, file);
+
+        if (best is Vala.Expression && !(best is Vala.Literal)) {
+            var b = (Vala.Expression)best;
+            debug ("best (%p) is a Expression (symbol_reference = %p)", best, b.symbol_reference);
+            if (b.symbol_reference != null && b.symbol_reference.source_reference != null) {
+                best = b.symbol_reference;
+                debug ("best is now the symbol_referenece => %p (%s)", best, best.to_string ());
+            }
+        } else if (best is Vala.DataType) {
+            best = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) best);
+        } else if (best is Vala.UsingDirective) {
+            best = ((Vala.UsingDirective)best).namespace_symbol;
+        } else if (best is Vala.Method) {
+            var m = (Vala.Method)best;
+
+            if (m.base_interface_method != m && m.base_interface_method != null)
+                best = m.base_interface_method;
+            else if (m.base_method != m && m.base_method != null)
+                best = m.base_method;
+        } else if (best is Vala.Property) {
+            var prop = (Vala.Property)best;
+
+            if (prop.base_interface_property != prop && prop.base_interface_property != null)
+                best = prop.base_interface_property;
+            else if (prop.base_property != prop && prop.base_property != null)
+                best = prop.base_property;
+        } else {
+            debug ("[%s] best is %s, which we can't handle", method, best != null ? best.type_name : null);
             Vala.CodeContext.pop ();
-        });
+            try {
+                yield client.reply_async (id, new Variant.maybe (VariantType.VARIANT, null), cancellable);
+            } catch (Error e) {
+                debug("[textDocument/definition] failed to reply to client: %s", e.message);
+            }
+            return;
+        }
+
+        if (best is Vala.Symbol)
+            best = SymbolReferences.find_real_symbol (selected_project, (Vala.Symbol) best);
+
+        var location = new Location.from_sourceref (best.source_reference);
+        debug ("[textDocument/definition] found location ... %s", location.uri);
+        Vala.CodeContext.pop ();
+        try {
+            yield client.reply_async (id, Util.object_to_variant (location), cancellable);
+        } catch (Error e) {
+            debug("[textDocument/definition] failed to reply to client: %s", e.message);
+        }
     }
 
-    void text_document_document_symbol (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void text_document_document_symbol_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1039,56 +1105,55 @@ class Vls.Server : Jsonrpc.Server {
         }
         if (results.is_empty) {
             debug (@"[$method] file `$(p.textDocument.uri)' not found");
-            reply_null (id, client, method);
+            yield reply_null_async (id, client, method);
             return;
         }
 
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, method);
-                return;
+        if (!yield wait_for_context_update_async (id, method)) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
+        // ignore multiple results
+        Vala.SourceFile file = results[0].first;
+        Compilation compilation = results[0].second;
+
+        if (compilation.code_context != file.context) {
+            // This means the file was probably deleted from the current code context,
+            // and so it's no longer valid. This is often the case for system files 
+            // that are added automatically in Vala.CodeContext
+            // This seems to be especially a problem on GNOME Builder, which runs
+            // this query on all files right after the user updates a file, but before
+            // the code context is updated.
+            debug ("[%s] file (%s) context != compilation.code_context; not proceeding further",
+                method, p.textDocument.uri);
+            return;
+        }
+
+        Vala.CodeContext.push (compilation.code_context);
+
+        var array = new Json.Array ();
+        var syms = compilation.get_analysis_for_file<SymbolEnumerator> (file) as SymbolEnumerator;
+        if (init_params.capabilities.textDocument.documentSymbol.hierarchicalDocumentSymbolSupport)
+            foreach (var dsym in syms) {
+                // debug(@"found $(dsym.name)");
+                array.add_element (Json.gobject_serialize (dsym));
             }
-
-            // ignore multiple results
-            Vala.SourceFile file = results[0].first;
-            Compilation compilation = results[0].second;
-
-            if (compilation.code_context != file.context) {
-                // This means the file was probably deleted from the current code context,
-                // and so it's no longer valid. This is often the case for system files 
-                // that are added automatically in Vala.CodeContext
-                // This seems to be especially a problem on GNOME Builder, which runs
-                // this query on all files right after the user updates a file, but before
-                // the code context is updated.
-                debug ("[%s] file (%s) context != compilation.code_context; not proceeding further",
-                    method, p.textDocument.uri);
-                return;
+        else {
+            foreach (var dsym in syms.flattened ()) {
+                // debug(@"found $(dsym.name)");
+                array.add_element (Json.gobject_serialize (dsym));
             }
+        }
 
-            Vala.CodeContext.push (compilation.code_context);
+        Vala.CodeContext.pop ();
 
-            var array = new Json.Array ();
-            var syms = compilation.get_analysis_for_file<SymbolEnumerator> (file) as SymbolEnumerator;
-            if (init_params.capabilities.textDocument.documentSymbol.hierarchicalDocumentSymbolSupport)
-                foreach (var dsym in syms) {
-                    // debug(@"found $(dsym.name)");
-                    array.add_element (Json.gobject_serialize (dsym));
-                }
-            else {
-                foreach (var dsym in syms.flattened ()) {
-                    // debug(@"found $(dsym.name)");
-                    array.add_element (Json.gobject_serialize (dsym));
-                }
-            }
-
-            try {
-                Variant result = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (array), null);
-                client.reply (id, result, cancellable);
-            } catch (Error e) {
-                debug (@"[textDocument/documentSymbol] failed to reply to client: $(e.message)");
-            }
-            Vala.CodeContext.pop ();
-        });
+        try {
+            Variant result = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (array), null);
+            yield client.reply_async (id, result, cancellable);
+        } catch (Error e) {
+            debug (@"[textDocument/documentSymbol] failed to reply to client: $(e.message)");
+        }
     }
 
     public DocComment? get_symbol_documentation (Project project, Vala.Symbol sym) {
@@ -1196,7 +1261,7 @@ class Vls.Server : Jsonrpc.Server {
                                             p.position);
     }
 
-    void text_document_hover (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void text_document_hover_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1214,160 +1279,158 @@ class Vls.Server : Jsonrpc.Server {
         }
         if (results.is_empty) {
             debug (@"file `$(Uri.unescape_string (p.textDocument.uri))' not found");
-            reply_null (id, client, "textDocument/hover");
+            yield reply_null_async (id, client, "textDocument/hover");
             return;
         }
 
         Position pos = p.position;
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, "textDocument/hover");
-                return;
-            }
+        if (!yield wait_for_context_update_async (id, method)) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
 
-            Vala.SourceFile doc = results[0].first;
-            Compilation compilation = results[0].second;
-            Vala.CodeContext.push (compilation.code_context);
+        Vala.SourceFile doc = results[0].first;
+        Compilation compilation = results[0].second;
+        Vala.CodeContext.push (compilation.code_context);
 
-            var fs = new FindSymbol (doc, pos, true);
+        var fs = new FindSymbol (doc, pos, true);
 
-            if (fs.result.size == 0) {
-                // debug ("[textDocument/hover] no results found");
-                reply_null (id, client, "textDocument/hover");
-                Vala.CodeContext.pop ();
-                return;
-            }
+        if (fs.result.size == 0) {
+            // debug ("[textDocument/hover] no results found");
+            Vala.CodeContext.pop ();
+            yield reply_null_async (id, client, method);
+            return;
+        }
 
-            Vala.Scope scope = (new FindScope (doc, pos)).best_block.scope;
-            Vala.CodeNode result = get_best (fs, doc);
-            // don't show lambda expressions on hover
-            // don't show property accessors
-            if (result is Vala.Method && ((Vala.Method)result).closure ||
-                result is Vala.PropertyAccessor) {
-                reply_null (id, client, "textDocument/hover");
-                Vala.CodeContext.pop ();
-                return;
-            }
+        Vala.Scope scope = (new FindScope (doc, pos)).best_block.scope;
+        Vala.CodeNode result = get_best (fs, doc);
+        // don't show lambda expressions on hover
+        // don't show property accessors
+        if (result is Vala.Method && ((Vala.Method)result).closure ||
+            result is Vala.PropertyAccessor) {
+            Vala.CodeContext.pop ();
+            yield reply_null_async (id, client, "textDocument/hover");
+            return;
+        }
 
-            // the instance's data type, used to resolve the symbol, which may be a member
-            Vala.DataType? data_type = null;
-            Vala.List<Vala.DataType>? method_type_arguments = null;
-            Vala.Symbol? symbol = null;
+        // the instance's data type, used to resolve the symbol, which may be a member
+        Vala.DataType? data_type = null;
+        Vala.List<Vala.DataType>? method_type_arguments = null;
+        Vala.Symbol? symbol = null;
 
-            if (result is Vala.Expression) {
-                var expr = (Vala.Expression) result;
-                symbol = expr.symbol_reference;
-                data_type = expr.value_type;
-                if (symbol != null && expr is Vala.MemberAccess) {
-                    var ma = (Vala.MemberAccess) expr;
-                    if (ma.inner != null && ma.inner.value_type != null) {
-                        // get inner's data_type, which we can use to resolve expr's generic type
-                        data_type = ma.inner.value_type;
-                    }
-                    method_type_arguments = ma.get_type_arguments ();
+        if (result is Vala.Expression) {
+            var expr = (Vala.Expression) result;
+            symbol = expr.symbol_reference;
+            data_type = expr.value_type;
+            if (symbol != null && expr is Vala.MemberAccess) {
+                var ma = (Vala.MemberAccess) expr;
+                if (ma.inner != null && ma.inner.value_type != null) {
+                    // get inner's data_type, which we can use to resolve expr's generic type
+                    data_type = ma.inner.value_type;
                 }
-
-                if (expr.parent_node is Vala.ObjectCreationExpression)
-                    data_type = ((Vala.ObjectCreationExpression)expr.parent_node).value_type;
-
-                // if data_type is the same as this variable's type, then this variable is not a member
-                // of the type 
-                // (note: this avoids variable's generic type arguments being resolved to InvalidType)
-                if (symbol is Vala.Variable && data_type != null && data_type.equals (((Vala.Variable)symbol).variable_type))
-                    data_type = null;
-            } else if (result is Vala.Symbol) {
-                symbol = (Vala.Symbol) result;
-            } else if (result is Vala.DataType) {
-                data_type = (Vala.DataType) result;
-                symbol = SymbolReferences.get_symbol_data_type_refers_to (data_type);
-            } else if (result is Vala.UsingDirective) {
-                symbol = ((Vala.UsingDirective)result).namespace_symbol;
-            } else {
-                warning ("result as %s not matched", result.type_name);
+                method_type_arguments = ma.get_type_arguments ();
             }
 
-            // don't show temporary variables
-            if (symbol != null && symbol.name != null && symbol.name[0] == '.' && symbol.name[1].isdigit ()) {
-                if (symbol is Vala.Variable && data_type == null)
-                    data_type = ((Vala.Variable)symbol).variable_type;
-                symbol = null;
-            }
+            if (expr.parent_node is Vala.ObjectCreationExpression)
+                data_type = ((Vala.ObjectCreationExpression)expr.parent_node).value_type;
 
-            // debug ("(parent) data_type is %s, symbol is %s",
-            //         CodeHelp.get_symbol_representation (data_type, null, scope, false),
-            //         CodeHelp.get_symbol_representation (null, symbol, scope, false));
+            // if data_type is the same as this variable's type, then this variable is not a member
+            // of the type 
+            // (note: this avoids variable's generic type arguments being resolved to InvalidType)
+            if (symbol is Vala.Variable && data_type != null && data_type.equals (((Vala.Variable)symbol).variable_type))
+                data_type = null;
+        } else if (result is Vala.Symbol) {
+            symbol = (Vala.Symbol) result;
+        } else if (result is Vala.DataType) {
+            data_type = (Vala.DataType) result;
+            symbol = SymbolReferences.get_symbol_data_type_refers_to (data_type);
+        } else if (result is Vala.UsingDirective) {
+            symbol = ((Vala.UsingDirective)result).namespace_symbol;
+        } else {
+            warning ("result as %s not matched", result.type_name);
+        }
 
-            var hoverInfo = new Hover ();
+        // don't show temporary variables
+        if (symbol != null && symbol.name != null && symbol.name[0] == '.' && symbol.name[1].isdigit ()) {
+            if (symbol is Vala.Variable && data_type == null)
+                data_type = ((Vala.Variable)symbol).variable_type;
+            symbol = null;
+        }
 
-            Range? symbol_range = null;
-            if (symbol != null) {
-                symbol_range = SymbolReferences.get_replacement_range (result, symbol);
-                if (symbol_range != null) {
-                    // if the symbol range does not include the cursor, then try
-                    // to get the hidden symbol at the cursor first
-                    bool found_component = false;
-                    if (!symbol_range.contains (pos)) {
-                        foreach (var component in SymbolReferences.get_visible_components_of_code_node (result)) {
-                            if (component.second.contains (pos)) {
-                                hoverInfo.range = component.second;
-                                symbol = component.first;
-                                data_type = null;
-                                method_type_arguments = null;
-                                found_component = true;
-                                break;
-                            }
+        // debug ("(parent) data_type is %s, symbol is %s",
+        //         CodeHelp.get_symbol_representation (data_type, null, scope, false),
+        //         CodeHelp.get_symbol_representation (null, symbol, scope, false));
+
+        var hoverInfo = new Hover ();
+
+        Range? symbol_range = null;
+        if (symbol != null) {
+            symbol_range = SymbolReferences.get_replacement_range (result, symbol);
+            if (symbol_range != null) {
+                // if the symbol range does not include the cursor, then try
+                // to get the hidden symbol at the cursor first
+                bool found_component = false;
+                if (!symbol_range.contains (pos)) {
+                    foreach (var component in SymbolReferences.get_visible_components_of_code_node (result)) {
+                        if (component.second.contains (pos)) {
+                            hoverInfo.range = component.second;
+                            symbol = component.first;
+                            data_type = null;
+                            method_type_arguments = null;
+                            found_component = true;
+                            break;
                         }
                     }
-                    if (!found_component)
-                        hoverInfo.range = symbol_range;
+                }
+                if (!found_component)
+                    hoverInfo.range = symbol_range;
+            }
+        }
+
+        if (symbol_range == null)
+            hoverInfo.range = new Range.from_sourceref (result.source_reference);
+
+        string? representation = CodeHelp.get_symbol_representation (data_type, symbol, scope, true, method_type_arguments);
+        if (representation != null) {
+            hoverInfo.contents.add (new MarkedString () {
+                language = "vala",
+                value = representation
+            });
+            
+            if (symbol != null) {
+                var comment = get_symbol_documentation (selected_project, symbol);
+                if (comment != null) {
+                    hoverInfo.contents.add (new MarkedString () {
+                        value = comment.body
+                    });
+                    // if (symbol is Vala.Callable && ((Vala.Callable)symbol).get_parameters () != null) {
+                    //     var param_list = ((Vala.Callable) symbol).get_parameters ();
+                    //     foreach (var parameter in param_list) {
+                    //         if (parameter.name == null)
+                    //             break;
+                    //         string? param_doc = comment.parameters[parameter.name];
+                    //         if (param_doc == null)
+                    //             continue;
+                    //         hoverInfo.contents.add (new MarkedString () {
+                    //             value = @"`$(parameter.name)` \u2014 $param_doc"
+                    //         });
+                    //     }
+                    // }
+                    // if (comment.return_body != null)
+                    //     hoverInfo.contents.add (new MarkedString () {
+                    //         value = @"**returns** $(comment.return_body)"
+                    //     });
                 }
             }
+        }
 
-            if (symbol_range == null)
-                hoverInfo.range = new Range.from_sourceref (result.source_reference);
+        Vala.CodeContext.pop ();
 
-            string? representation = CodeHelp.get_symbol_representation (data_type, symbol, scope, true, method_type_arguments);
-            if (representation != null) {
-                hoverInfo.contents.add (new MarkedString () {
-                    language = "vala",
-                    value = representation
-                });
-                
-                if (symbol != null) {
-                    var comment = get_symbol_documentation (selected_project, symbol);
-                    if (comment != null) {
-                        hoverInfo.contents.add (new MarkedString () {
-                            value = comment.body
-                        });
-                        // if (symbol is Vala.Callable && ((Vala.Callable)symbol).get_parameters () != null) {
-                        //     var param_list = ((Vala.Callable) symbol).get_parameters ();
-                        //     foreach (var parameter in param_list) {
-                        //         if (parameter.name == null)
-                        //             break;
-                        //         string? param_doc = comment.parameters[parameter.name];
-                        //         if (param_doc == null)
-                        //             continue;
-                        //         hoverInfo.contents.add (new MarkedString () {
-                        //             value = @"`$(parameter.name)` \u2014 $param_doc"
-                        //         });
-                        //     }
-                        // }
-                        // if (comment.return_body != null)
-                        //     hoverInfo.contents.add (new MarkedString () {
-                        //         value = @"**returns** $(comment.return_body)"
-                        //     });
-                    }
-                }
-            }
-
-            try {
-                client.reply (id, Util.object_to_variant (hoverInfo), cancellable);
-            } catch (Error e) {
-                warning ("[textDocument/hover] failed to reply to client: %s", e.message);
-            }
-
-            Vala.CodeContext.pop ();
-        });
+        try {
+            yield client.reply_async (id, Util.object_to_variant (hoverInfo), cancellable);
+        } catch (Error e) {
+            warning ("[textDocument/hover] failed to reply to client: %s", e.message);
+        }
     }
 
     DocumentHighlightKind determine_node_highlight_kind (Vala.CodeNode node) {
@@ -1397,7 +1460,7 @@ class Vls.Server : Jsonrpc.Server {
         return DocumentHighlightKind.Text;
     }
 
-    void text_document_references (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void text_document_references_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<ReferenceParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1415,101 +1478,99 @@ class Vls.Server : Jsonrpc.Server {
         }
         if (results.is_empty) {
             debug (@"file `$(Uri.unescape_string (p.textDocument.uri))' not found");
-            reply_null (id, client, method);
+            yield reply_null_async (id, client, method);
             return;
         }
 
         Position pos = p.position;
         bool is_highlight = method == "textDocument/documentHighlight";
         bool include_declaration = p.context != null ? p.context.includeDeclaration : true;
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, method);
-                return;
-            }
+        if (!yield wait_for_context_update_async (id, method)) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
 
-            Vala.SourceFile doc = results[0].first;
-            Compilation compilation = results[0].second;
-            Vala.CodeContext.push (compilation.code_context);
+        Vala.SourceFile doc = results[0].first;
+        Compilation compilation = results[0].second;
+        Vala.CodeContext.push (compilation.code_context);
 
-            var fs = new FindSymbol (doc, pos, true);
+        var fs = new FindSymbol (doc, pos, true);
 
-            if (fs.result.size == 0) {
-                debug (@"[$method] no results found");
-                reply_null (id, client, method);
-                Vala.CodeContext.pop ();
-                return;
-            }
-
-            Vala.CodeNode result = get_best (fs, doc);
-            Vala.Symbol symbol;
-            var json_array = new Json.Array ();
-            var references = new Gee.HashMap<Range, Vala.CodeNode> ();
-
-            if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
-                result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType) {
-                result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
-            } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
-                result = ((Vala.UsingDirective) result).namespace_symbol;
-
-            // ignore lambda expressions and non-symbols
-            if (!(result is Vala.Symbol) ||
-                result is Vala.Method && ((Vala.Method)result).closure) {
-                reply_null (id, client, method);
-                Vala.CodeContext.pop ();
-                return;
-            }
-
-            symbol = (Vala.Symbol) result;
-
-            debug (@"[$method] got best: $result ($(result.type_name))");
-            if (is_highlight || symbol is Vala.LocalVariable) {
-                // if highlight, show references in current file
-                // otherwise, we may also do this if it's a local variable, since
-                // Server.get_compilations_using_symbol() only works for global symbols
-                SymbolReferences.list_in_file (doc, symbol, include_declaration, references);
-            } else {
-                // show references in all files
-                var generated_vapis = new HashSet<File> (Util.file_hash, Util.file_equal);
-                foreach (var btarget in selected_project.get_compilations ())
-                    generated_vapis.add_all (btarget.output);
-                var shown_files = new HashSet<File> (Util.file_hash, Util.file_equal);
-                foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol))
-                    foreach (Vala.SourceFile project_file in btarget_w_sym.first.code_context.get_source_files ()) {
-                        // don't show symbol from generated VAPI
-                        var file = File.new_for_commandline_arg (project_file.filename);
-                        if (file in generated_vapis || file in shown_files)
-                            continue;
-                        SymbolReferences.list_in_file (project_file, btarget_w_sym.second, include_declaration, references);
-                        shown_files.add (file);
-                    }
-            }
-            
-            debug (@"[$method] found $(references.size) reference(s)");
-            foreach (var entry in references) {
-                if (is_highlight) {
-                    json_array.add_element (Json.gobject_serialize (new DocumentHighlight () {
-                        range = entry.key,
-                        kind = determine_node_highlight_kind (entry.value)
-                    }));
-                } else {
-                    json_array.add_element (Json.gobject_serialize (new Location (entry.value.source_reference.file.filename, entry.key)));
-                }
-            }
-
-            try {
-                Variant variant_array = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (json_array), null);
-                client.reply (id, variant_array, cancellable);
-            } catch (Error e) {
-                debug (@"[$method] failed to reply to client: $(e.message)");
-            }
-
+        if (fs.result.size == 0) {
+            debug (@"[$method] no results found");
             Vala.CodeContext.pop ();
-        });
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
+        Vala.CodeNode result = get_best (fs, doc);
+        Vala.Symbol symbol;
+        var json_array = new Json.Array ();
+        var references = new Gee.HashMap<Range, Vala.CodeNode> ();
+
+        if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
+            result = ((Vala.Expression) result).symbol_reference;
+        else if (result is Vala.DataType) {
+            result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
+        } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
+            result = ((Vala.UsingDirective) result).namespace_symbol;
+
+        // ignore lambda expressions and non-symbols
+        if (!(result is Vala.Symbol) ||
+            result is Vala.Method && ((Vala.Method)result).closure) {
+            Vala.CodeContext.pop ();
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
+        symbol = (Vala.Symbol) result;
+
+        debug (@"[$method] got best: $result ($(result.type_name))");
+        if (is_highlight || symbol is Vala.LocalVariable) {
+            // if highlight, show references in current file
+            // otherwise, we may also do this if it's a local variable, since
+            // Server.get_compilations_using_symbol() only works for global symbols
+            SymbolReferences.list_in_file (doc, symbol, include_declaration, references);
+        } else {
+            // show references in all files
+            var generated_vapis = new HashSet<File> (Util.file_hash, Util.file_equal);
+            foreach (var btarget in selected_project.get_compilations ())
+                generated_vapis.add_all (btarget.output);
+            var shown_files = new HashSet<File> (Util.file_hash, Util.file_equal);
+            foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol))
+                foreach (Vala.SourceFile project_file in btarget_w_sym.first.code_context.get_source_files ()) {
+                    // don't show symbol from generated VAPI
+                    var file = File.new_for_commandline_arg (project_file.filename);
+                    if (file in generated_vapis || file in shown_files)
+                        continue;
+                    SymbolReferences.list_in_file (project_file, btarget_w_sym.second, include_declaration, references);
+                    shown_files.add (file);
+                }
+        }
+        
+        debug (@"[$method] found $(references.size) reference(s)");
+        foreach (var entry in references) {
+            if (is_highlight) {
+                json_array.add_element (Json.gobject_serialize (new DocumentHighlight () {
+                    range = entry.key,
+                    kind = determine_node_highlight_kind (entry.value)
+                }));
+            } else {
+                json_array.add_element (Json.gobject_serialize (new Location (entry.value.source_reference.file.filename, entry.key)));
+            }
+        }
+
+        Vala.CodeContext.pop ();
+
+        try {
+            Variant variant_array = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (json_array), null);
+            yield client.reply_async (id, variant_array, cancellable);
+        } catch (Error e) {
+            debug (@"[$method] failed to reply to client: $(e.message)");
+        }
     }
 
-    void text_document_implementation (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void text_document_implementation_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<Lsp.TextDocumentPositionParams>(@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1527,105 +1588,99 @@ class Vls.Server : Jsonrpc.Server {
         }
         if (results.is_empty) {
             debug (@"file `$(Uri.unescape_string (p.textDocument.uri))' not found");
-            reply_null (id, client, method);
+            yield reply_null_async (id, client, method);
             return;
         }
 
         Position pos = p.position;
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, method);
-                return;
-            }
 
-            Vala.SourceFile doc = results[0].first;
-            Compilation compilation = results[0].second;
-            Vala.CodeContext.push (compilation.code_context);
+        Vala.SourceFile doc = results[0].first;
+        Compilation compilation = results[0].second;
+        Vala.CodeContext.push (compilation.code_context);
 
-            var fs = new FindSymbol (doc, pos, true);
+        var fs = new FindSymbol (doc, pos, true);
 
-            if (fs.result.size == 0) {
-                debug (@"[$method] no results found");
-                reply_null (id, client, method);
-                Vala.CodeContext.pop ();
-                return;
-            }
-
-            Vala.CodeNode result = get_best (fs, doc);
-            Vala.Symbol symbol;
-
-            var json_array = new Json.Array ();
-            var references = new Gee.ArrayList<Vala.CodeNode> ();
-
-            if (result is Vala.DataType && ((Vala.DataType)result).type_symbol != null)
-                result = ((Vala.DataType) result).type_symbol;
-
-            debug (@"[$method] got best: $result ($(result.type_name))");
-            bool is_abstract_type = (result is Vala.Interface) || ((result is Vala.Class) && ((Vala.Class)result).is_abstract);
-            bool is_abstract_or_virtual_method = (result is Vala.Method) && 
-                (((Vala.Method)result).is_abstract || ((Vala.Method)result).is_virtual);
-            bool is_abstract_or_virtual_property = (result is Vala.Property) &&
-                (((Vala.Property)result).is_abstract || ((Vala.Property)result).is_virtual);
-
-            if (!is_abstract_type && !is_abstract_or_virtual_method && !is_abstract_or_virtual_property) {
-                debug (@"[$method] best is neither an abstract type/interface nor abstract/virtual method/property");
-                reply_null (id, client, method);
-                Vala.CodeContext.pop ();
-                return;
-            } else {
-                symbol = (Vala.Symbol) result;
-            }
-
-            // show references in all files
-            var generated_vapis = new HashSet<File> (Util.file_hash, Util.file_equal);
-            foreach (var btarget in selected_project.get_compilations ())
-                generated_vapis.add_all (btarget.output);
-            var shown_files = new HashSet<File> (Util.file_hash, Util.file_equal);
-            foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol)) {
-                foreach (var file in btarget_w_sym.first.code_context.get_source_files ()) {
-                    var gfile = File.new_for_commandline_arg (file.filename);
-                    // don't show symbol from generated VAPI
-                    if (gfile in generated_vapis || gfile in shown_files)
-                        continue;
-
-                    FindSymbol fs2;
-                    if (is_abstract_type) {
-                        fs2 = new FindSymbol.with_filter (file, btarget_w_sym.second,
-                        (needle, node) => node is Vala.ObjectTypeSymbol && 
-                            ((Vala.ObjectTypeSymbol)node).is_subtype_of ((Vala.ObjectTypeSymbol) needle), false);
-                    } else if (is_abstract_or_virtual_method) {
-                        fs2 = new FindSymbol.with_filter (file, btarget_w_sym.second,
-                        (needle, node) => needle != node && (node is Vala.Method) && 
-                            (((Vala.Method)node).base_method == needle ||
-                            ((Vala.Method)node).base_interface_method == needle), false);
-                    } else {
-                        fs2 = new FindSymbol.with_filter (file, symbol,
-                        (needle, node) => needle != node && (node is Vala.Property) &&
-                            (((Vala.Property)node).base_property == needle ||
-                            ((Vala.Property)node).base_interface_property == needle), false);
-                    }
-                    references.add_all (fs2.result);
-                    shown_files.add (gfile);
-                }
-            }
-
-            debug (@"[$method] found $(references.size) reference(s)");
-            foreach (var node in references) {
-                Vala.CodeNode real_node = node;
-                if (node is Vala.Symbol)
-                    real_node = SymbolReferences.find_real_symbol (selected_project, (Vala.Symbol) node);
-                json_array.add_element (Json.gobject_serialize (new Location.from_sourceref (real_node.source_reference)));
-            }
-
-            try {
-                Variant variant_array = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (json_array), null);
-                client.reply (id, variant_array, cancellable);
-            } catch (Error e) {
-                debug (@"[$method] failed to reply to client: $(e.message)");
-            }
-
+        if (fs.result.size == 0) {
+            debug (@"[$method] no results found");
             Vala.CodeContext.pop ();
-        });
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
+        Vala.CodeNode result = get_best (fs, doc);
+        Vala.Symbol symbol;
+
+        var json_array = new Json.Array ();
+        var references = new Gee.ArrayList<Vala.CodeNode> ();
+
+        if (result is Vala.DataType && ((Vala.DataType)result).type_symbol != null)
+            result = ((Vala.DataType) result).type_symbol;
+
+        debug (@"[$method] got best: $result ($(result.type_name))");
+        bool is_abstract_type = (result is Vala.Interface) || ((result is Vala.Class) && ((Vala.Class)result).is_abstract);
+        bool is_abstract_or_virtual_method = (result is Vala.Method) && 
+            (((Vala.Method)result).is_abstract || ((Vala.Method)result).is_virtual);
+        bool is_abstract_or_virtual_property = (result is Vala.Property) &&
+            (((Vala.Property)result).is_abstract || ((Vala.Property)result).is_virtual);
+
+        if (!is_abstract_type && !is_abstract_or_virtual_method && !is_abstract_or_virtual_property) {
+            debug (@"[$method] best is neither an abstract type/interface nor abstract/virtual method/property");
+            Vala.CodeContext.pop ();
+            yield reply_null_async (id, client, method);
+            return;
+        } else {
+            symbol = (Vala.Symbol) result;
+        }
+
+        // show references in all files
+        var generated_vapis = new HashSet<File> (Util.file_hash, Util.file_equal);
+        foreach (var btarget in selected_project.get_compilations ())
+            generated_vapis.add_all (btarget.output);
+        var shown_files = new HashSet<File> (Util.file_hash, Util.file_equal);
+        foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol)) {
+            foreach (var file in btarget_w_sym.first.code_context.get_source_files ()) {
+                var gfile = File.new_for_commandline_arg (file.filename);
+                // don't show symbol from generated VAPI
+                if (gfile in generated_vapis || gfile in shown_files)
+                    continue;
+
+                FindSymbol fs2;
+                if (is_abstract_type) {
+                    fs2 = new FindSymbol.with_filter (file, btarget_w_sym.second,
+                    (needle, node) => node is Vala.ObjectTypeSymbol && 
+                        ((Vala.ObjectTypeSymbol)node).is_subtype_of ((Vala.ObjectTypeSymbol) needle), false);
+                } else if (is_abstract_or_virtual_method) {
+                    fs2 = new FindSymbol.with_filter (file, btarget_w_sym.second,
+                    (needle, node) => needle != node && (node is Vala.Method) && 
+                        (((Vala.Method)node).base_method == needle ||
+                        ((Vala.Method)node).base_interface_method == needle), false);
+                } else {
+                    fs2 = new FindSymbol.with_filter (file, symbol,
+                    (needle, node) => needle != node && (node is Vala.Property) &&
+                        (((Vala.Property)node).base_property == needle ||
+                        ((Vala.Property)node).base_interface_property == needle), false);
+                }
+                references.add_all (fs2.result);
+                shown_files.add (gfile);
+            }
+        }
+
+        debug (@"[$method] found $(references.size) reference(s)");
+        foreach (var node in references) {
+            Vala.CodeNode real_node = node;
+            if (node is Vala.Symbol)
+                real_node = SymbolReferences.find_real_symbol (selected_project, (Vala.Symbol) node);
+            json_array.add_element (Json.gobject_serialize (new Location.from_sourceref (real_node.source_reference)));
+        }
+
+        Vala.CodeContext.pop ();
+
+        try {
+            Variant variant_array = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (json_array), null);
+            yield client.reply_async (id, variant_array, cancellable);
+        } catch (Error e) {
+            debug (@"[$method] failed to reply to client: $(e.message)");
+        }
     }
     
     void text_document_formatting (Jsonrpc.Client client, string method, Variant id, Variant @params) {
@@ -1676,59 +1731,62 @@ class Vls.Server : Jsonrpc.Server {
         }
     }
 
-    void workspace_symbol (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void workspace_symbol_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var query = (string) @params.lookup_value ("query", VariantType.STRING);
 
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, method);
-                return;
-            }
+        if (!yield wait_for_context_update_async (id, method)) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
 
-            var json_array = new Json.Array ();
-            Project[] all_projects = projects.get_keys_as_array ();
-            all_projects += default_project;
-            foreach (var project in all_projects) {
-                foreach (var source_pair in project.get_project_source_files ()) {
-                    var text_document = source_pair.key;
-                    var compilation = source_pair.value;
-                    Vala.CodeContext.push (compilation.code_context);
-                    var symbol_enumerator = compilation.get_analysis_for_file<SymbolEnumerator> (text_document) as SymbolEnumerator;
-                    if (symbol_enumerator != null) {
-                        symbol_enumerator
-                            .flattened ()
-                            // NOTE: if introspection for g_str_match_string () / string.match_string ()
-                            // is fixed, this will have to be changed to `dsym.name.match_sting (query, true)`
-                            .filter (dsym => query.match_string (dsym.name, true))
-                            .foreach (dsym => {
-                                json_array.add_element (Json.gobject_serialize (dsym));
-                                return true;
-                            });
-                    }
-                    Vala.CodeContext.pop ();
+        var json_array = new Json.Array ();
+        Project[] all_projects = projects.get_keys_as_array ();
+        all_projects += default_project;
+        foreach (var project in all_projects) {
+            foreach (var source_pair in project.get_project_source_files ()) {
+                var text_document = source_pair.key;
+                var compilation = source_pair.value;
+                Vala.CodeContext.push (compilation.code_context);
+                var symbol_enumerator = compilation.get_analysis_for_file<SymbolEnumerator> (text_document) as SymbolEnumerator;
+                if (symbol_enumerator != null) {
+                    symbol_enumerator
+                        .flattened ()
+                        // NOTE: if introspection for g_str_match_string () / string.match_string ()
+                        // is fixed, this will have to be changed to `dsym.name.match_sting (query, true)`
+                        .filter (dsym => query.match_string (dsym.name, true))
+                        .foreach (dsym => {
+                            json_array.add_element (Json.gobject_serialize (dsym));
+                            return true;
+                        });
                 }
+                Vala.CodeContext.pop ();
             }
+        }
 
-            debug (@"[$method] found $(json_array.get_length ()) element(s) matching `$query'");
-            try {
-                Variant variant_array = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (json_array), null);
-                client.reply (id, variant_array, cancellable);
-            } catch (Error e) {
-                debug (@"[$method] failed to reply to client: $(e.message)");
-            }
-        });
+        debug (@"[$method] found $(json_array.get_length ()) element(s) matching `$query'");
+        try {
+            Variant variant_array = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (json_array), null);
+            yield client.reply_async (id, variant_array, cancellable);
+        } catch (Error e) {
+            debug (@"[$method] failed to reply to client: $(e.message)");
+        }
     }
 
-    void text_document_rename (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void text_document_rename_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         string new_name = (string) @params.lookup_value ("newName", VariantType.STRING);
 
         // before anything, sanity-check the new symbol name
         if (!/^(?=[^\d])[^\s~`!#%^&*()\-\+={}\[\]|\\\/?.>,<'";:]+$/.match (new_name)) {
-            client.reply_error_async.begin (
-                id, 
-                Jsonrpc.ClientError.INVALID_REQUEST, 
-                "Invalid symbol name. Symbol names cannot start with a number and must not contain any operators.", 
-                cancellable);
+            try {
+                yield client.reply_error_async (
+                    id, 
+                    Jsonrpc.ClientError.INVALID_REQUEST, 
+                    "Invalid symbol name. Symbol names cannot start with a number and must not contain any operators.", 
+                    cancellable
+                );
+            } catch (Error e) {
+                debug ("[%s] failed to reply to client with error - %s", method, e.message);
+            }
             return;
         }
 
@@ -1749,144 +1807,142 @@ class Vls.Server : Jsonrpc.Server {
         }
         if (results.is_empty) {
             debug (@"file `$(Uri.unescape_string (p.textDocument.uri))' not found");
-            reply_null (id, client, method);
+            yield reply_null_async (id, client, method);
             return;
         }
 
         Position pos = p.position;
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, method);
-                return;
-            }
+        if (!yield wait_for_context_update_async (id, method)) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
 
-            Vala.SourceFile doc = results[0].first;
-            Compilation compilation = results[0].second;
-            Vala.CodeContext.push (compilation.code_context);
+        Vala.SourceFile doc = results[0].first;
+        Compilation compilation = results[0].second;
+        Vala.CodeContext.push (compilation.code_context);
 
-            var fs = new FindSymbol (doc, pos, true);
+        var fs = new FindSymbol (doc, pos, true);
 
-            if (fs.result.size == 0) {
-                debug (@"[$method] no results found");
-                reply_null (id, client, method);
-                Vala.CodeContext.pop ();
-                return;
-            }
-
-            Vala.CodeNode result = get_best (fs, doc);
-            Vala.Symbol symbol;
-            var references = new Gee.HashMap<Range, Vala.CodeNode> ();
-
-            if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
-                result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType) {
-                result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
-            } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
-                result = ((Vala.UsingDirective) result).namespace_symbol;
-
-            // ignore lambda expressions and non-symbols
-            if (!(result is Vala.Symbol) ||
-                result is Vala.Method && ((Vala.Method)result).closure) {
-                debug ("[%s] result is not a symbol", method);
-                reply_null (id, client, method);
-                Vala.CodeContext.pop ();
-                return;
-            }
-
-            symbol = (Vala.Symbol) result;
-
-            debug ("[%s] got symbol %s @ %s", method, symbol.get_full_name (), symbol.source_reference.to_string ());
-
-            // get references in all files
-            var generated_vapis = new HashSet<File> (Util.file_hash, Util.file_equal);
-            foreach (var btarget in selected_project.get_compilations ())
-                generated_vapis.add_all (btarget.output);
-            var shown_files = new HashSet<File> (Util.file_hash, Util.file_equal);
-            bool is_abstract_or_virtual = 
-                symbol is Vala.Property && (((Vala.Property)symbol).is_virtual || ((Vala.Property)symbol).is_abstract) ||
-                symbol is Vala.Method && (((Vala.Method)symbol).is_virtual || ((Vala.Method)symbol).is_abstract) ||
-                symbol is Vala.Signal && ((Vala.Signal)symbol).is_virtual;
-            foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol))
-                foreach (Vala.SourceFile project_file in btarget_w_sym.first.code_context.get_source_files ()) {
-                    // don't show symbol from generated VAPI
-                    var file = File.new_for_commandline_arg (project_file.filename);
-                    if (file in generated_vapis || file in shown_files)
-                        continue;
-                    var file_references = new HashMap<Range, Vala.CodeNode> ();
-                    debug ("[%s] looking for references in %s ...", method, file.get_uri ());
-                    SymbolReferences.list_in_file (project_file, btarget_w_sym.second, true, file_references);
-                    if (is_abstract_or_virtual) {
-                        debug ("[%s] looking for implementations of abstract/virtual symbol in %s ...", method, file.get_uri ());
-                        SymbolReferences.list_implementations_of_virtual_symbol (project_file, btarget_w_sym.second, file_references);
-                    }
-                    if (!(project_file is TextDocument) && file_references.size > 0) {
-                        // This means we have found references in a file that was added automatically,
-                        // which should not be modified.
-                        debug ("[%s] disallowing requested modification of %s", method, project_file.filename);
-                        reply_null (id, client, method);
-                        Vala.CodeContext.pop ();
-                        return;
-                    }
-                    foreach (var entry in file_references)
-                        references[entry.key] = entry.value;
-                    shown_files.add (file);
-                }
-            
-            debug ("[%s] found %d references", method, references.size);
-            
-            // construct the edits for the text documents
-            // map: file URI -> TextEdit[]
-            var edits = new HashMap<string, ArrayList<TextEdit>> ();
-            var source_files = new HashMap<string, Vala.SourceFile> ();
-
-            foreach (var entry in references) {
-                var code_node = entry.value;
-                var source_range = entry.key;
-                debug ("[%s] editing reference %s @ %s ...", 
-                    method, 
-                    CodeHelp.get_expression_representation (code_node), 
-                    code_node.source_reference.to_string ());
-                var file = File.new_for_commandline_arg (code_node.source_reference.file.filename);
-                if (!edits.has_key (file.get_uri ()))
-                    edits[file.get_uri ()] = new ArrayList<TextEdit> ();
-                var file_edits = edits[file.get_uri ()];
-                // if this is a using directive, we want to only replace the part after the 'using' keyword
-                file_edits.add (new TextEdit () {
-                    range = source_range,
-                    newText = new_name
-                });
-                source_files[file.get_uri ()] = code_node.source_reference.file;
-            }
-
-            // TODO: determine support for TextDocumentEdit
-            var text_document_edits_json = new Json.Array ();
-            foreach (var uri in edits.keys) {
-                text_document_edits_json.add_element (Json.gobject_serialize (new TextDocumentEdit () {
-                    textDocument = new VersionedTextDocumentIdentifier () {
-                        version = ((TextDocument) source_files[uri]).version,
-                        uri = uri
-                    },
-                    edits = edits[uri]
-                }));
-            }
-
-            try {
-                Variant changes = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (text_document_edits_json), null);
-                client.reply (
-                    id, 
-                    build_dict (
-                        documentChanges: changes
-                    ),
-                    cancellable);
-            } catch (Error e) {
-                warning ("[%s] failed to reply to client - %s", method, e.message);
-            }
-
+        if (fs.result.size == 0) {
+            debug (@"[$method] no results found");
             Vala.CodeContext.pop ();
-        });
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
+        Vala.CodeNode result = get_best (fs, doc);
+        Vala.Symbol symbol;
+        var references = new Gee.HashMap<Range, Vala.CodeNode> ();
+
+        if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
+            result = ((Vala.Expression) result).symbol_reference;
+        else if (result is Vala.DataType) {
+            result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
+        } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
+            result = ((Vala.UsingDirective) result).namespace_symbol;
+
+        // ignore lambda expressions and non-symbols
+        if (!(result is Vala.Symbol) ||
+            result is Vala.Method && ((Vala.Method)result).closure) {
+            debug ("[%s] result is not a symbol", method);
+            Vala.CodeContext.pop ();
+            yield reply_null_async (id, client, method);
+            return;
+        }
+
+        symbol = (Vala.Symbol) result;
+
+        debug ("[%s] got symbol %s @ %s", method, symbol.get_full_name (), symbol.source_reference.to_string ());
+
+        // get references in all files
+        var generated_vapis = new HashSet<File> (Util.file_hash, Util.file_equal);
+        foreach (var btarget in selected_project.get_compilations ())
+            generated_vapis.add_all (btarget.output);
+        var shown_files = new HashSet<File> (Util.file_hash, Util.file_equal);
+        bool is_abstract_or_virtual = 
+            symbol is Vala.Property && (((Vala.Property)symbol).is_virtual || ((Vala.Property)symbol).is_abstract) ||
+            symbol is Vala.Method && (((Vala.Method)symbol).is_virtual || ((Vala.Method)symbol).is_abstract) ||
+            symbol is Vala.Signal && ((Vala.Signal)symbol).is_virtual;
+        foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol))
+            foreach (Vala.SourceFile project_file in btarget_w_sym.first.code_context.get_source_files ()) {
+                // don't show symbol from generated VAPI
+                var file = File.new_for_commandline_arg (project_file.filename);
+                if (file in generated_vapis || file in shown_files)
+                    continue;
+                var file_references = new HashMap<Range, Vala.CodeNode> ();
+                debug ("[%s] looking for references in %s ...", method, file.get_uri ());
+                SymbolReferences.list_in_file (project_file, btarget_w_sym.second, true, file_references);
+                if (is_abstract_or_virtual) {
+                    debug ("[%s] looking for implementations of abstract/virtual symbol in %s ...", method, file.get_uri ());
+                    SymbolReferences.list_implementations_of_virtual_symbol (project_file, btarget_w_sym.second, file_references);
+                }
+                if (!(project_file is TextDocument) && file_references.size > 0) {
+                    // This means we have found references in a file that was added automatically,
+                    // which should not be modified.
+                    debug ("[%s] disallowing requested modification of %s", method, project_file.filename);
+                    Vala.CodeContext.pop ();
+                    yield reply_null_async (id, client, method);
+                    return;
+                }
+                foreach (var entry in file_references)
+                    references[entry.key] = entry.value;
+                shown_files.add (file);
+            }
+        
+        debug ("[%s] found %d references", method, references.size);
+        
+        // construct the edits for the text documents
+        // map: file URI -> TextEdit[]
+        var edits = new HashMap<string, ArrayList<TextEdit>> ();
+        var source_files = new HashMap<string, Vala.SourceFile> ();
+
+        foreach (var entry in references) {
+            var code_node = entry.value;
+            var source_range = entry.key;
+            debug ("[%s] editing reference %s @ %s ...", 
+                method, 
+                CodeHelp.get_expression_representation (code_node), 
+                code_node.source_reference.to_string ());
+            var file = File.new_for_commandline_arg (code_node.source_reference.file.filename);
+            if (!edits.has_key (file.get_uri ()))
+                edits[file.get_uri ()] = new ArrayList<TextEdit> ();
+            var file_edits = edits[file.get_uri ()];
+            // if this is a using directive, we want to only replace the part after the 'using' keyword
+            file_edits.add (new TextEdit () {
+                range = source_range,
+                newText = new_name
+            });
+            source_files[file.get_uri ()] = code_node.source_reference.file;
+        }
+
+        // TODO: determine support for TextDocumentEdit
+        var text_document_edits_json = new Json.Array ();
+        foreach (var uri in edits.keys) {
+            text_document_edits_json.add_element (Json.gobject_serialize (new TextDocumentEdit () {
+                textDocument = new VersionedTextDocumentIdentifier () {
+                    version = ((TextDocument) source_files[uri]).version,
+                    uri = uri
+                },
+                edits = edits[uri]
+            }));
+        }
+
+        Vala.CodeContext.pop ();
+
+        try {
+            Variant changes = Json.gvariant_deserialize (new Json.Node.alloc ().init_array (text_document_edits_json), null);
+            yield client.reply_async (id, 
+                build_dict (
+                    documentChanges: changes
+                ),
+                cancellable
+            );
+        } catch (Error e) {
+            warning ("[%s] failed to reply to client - %s", method, e.message);
+        }
     }
     
-    void text_document_prepare_rename (Jsonrpc.Client client, string method, Variant id, Variant @params) {
+    async void text_document_prepare_rename_async (Jsonrpc.Client client, string method, Variant id, Variant @params) {
         var p = Util.parse_variant<TextDocumentPositionParams> (@params);
         var results = new ArrayList<Pair<Vala.SourceFile, Compilation>> ();
         Project selected_project = null;
@@ -1904,101 +1960,118 @@ class Vls.Server : Jsonrpc.Server {
         }
         if (results.is_empty) {
             debug (@"file `$(Uri.unescape_string (p.textDocument.uri))' not found");
-            reply_null (id, client, method);
+            yield reply_null_async (id, client, method);
             return;
         }
 
         Position pos = p.position;
-        wait_for_context_update (id, request_cancelled => {
-            if (request_cancelled) {
-                reply_null (id, client, method);
-                return;
-            }
-            
-            Vala.SourceFile doc = results[0].first;
-            Compilation compilation = results[0].second;
-            Vala.CodeContext.push (compilation.code_context);
+        if (!yield wait_for_context_update_async (id, method)) {
+            yield reply_null_async (id, client, method);
+            return;
+        }
 
-            var fs = new FindSymbol (doc, pos, true);
+        Vala.SourceFile doc = results[0].first;
+        Compilation compilation = results[0].second;
+        Vala.CodeContext.push (compilation.code_context);
 
-            if (fs.result.size == 0) {
-                client.reply_error_async.begin (
+        var fs = new FindSymbol (doc, pos, true);
+
+        if (fs.result.size == 0) {
+            Vala.CodeContext.pop ();
+            try {
+                yield client.reply_error_async (
                     id,
                     Jsonrpc.ClientError.INVALID_REQUEST,
                     "There is no symbol at the cursor.",
-                    cancellable);
-                Vala.CodeContext.pop ();
-                return;
+                    cancellable
+                );
+            } catch (Error e) {
+                warning ("[%s] failed to reply with error - %s", method, e.message);
             }
+            return;
+        }
 
-            Vala.CodeNode initial_result = get_best (fs, doc);
-            Vala.CodeNode result = initial_result;
-            Vala.Symbol symbol;
+        Vala.CodeNode initial_result = get_best (fs, doc);
+        Vala.CodeNode result = initial_result;
+        Vala.Symbol symbol;
 
-            if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
-                result = ((Vala.Expression) result).symbol_reference;
-            else if (result is Vala.DataType) {
-                result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
-            } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
-                result = ((Vala.UsingDirective) result).namespace_symbol;
+        if (result is Vala.Expression && ((Vala.Expression)result).symbol_reference != null)
+            result = ((Vala.Expression) result).symbol_reference;
+        else if (result is Vala.DataType) {
+            result = SymbolReferences.get_symbol_data_type_refers_to ((Vala.DataType) result);
+        } else if (result is Vala.UsingDirective && ((Vala.UsingDirective)result).namespace_symbol != null)
+            result = ((Vala.UsingDirective) result).namespace_symbol;
 
-            // ignore lambda expressions and non-symbols
-            if (!(result is Vala.Symbol) ||
-                result is Vala.Method && ((Vala.Method)result).closure) {
-                // TODO: rewrite all code to use async
-                client.reply_error_async.begin (
+        // ignore lambda expressions and non-symbols
+        if (!(result is Vala.Symbol) ||
+            result is Vala.Method && ((Vala.Method)result).closure) {
+            Vala.CodeContext.pop ();
+            try {
+                yield client.reply_error_async (
                     id, 
                     Jsonrpc.ClientError.INVALID_REQUEST, 
                     "There is no symbol at the cursor.", 
-                    cancellable);
-                Vala.CodeContext.pop ();
-                return;
+                    cancellable
+                );
+            } catch (Error e) {
+                warning ("[%s] failed to reply with error - %s", method, e.message);
             }
+            return;
+        }
 
-            symbol = (Vala.Symbol) result;
+        symbol = (Vala.Symbol) result;
 
-            var replacement_range = SymbolReferences.get_replacement_range (initial_result, symbol);
-            // If the source_reference is null, then this could be something like a
-            // `this' parameter.
-            if (replacement_range == null || symbol.source_reference == null) {
-                client.reply_error_async.begin (
+        var replacement_range = SymbolReferences.get_replacement_range (initial_result, symbol);
+        // If the source_reference is null, then this could be something like a
+        // `this' parameter.
+        if (replacement_range == null || symbol.source_reference == null) {
+            Vala.CodeContext.pop ();
+            try {
+                yield client.reply_error_async (
                     id,
                     Jsonrpc.ClientError.INVALID_REQUEST,
                     "There is no symbol at the cursor.",
-                    cancellable);
-                Vala.CodeContext.pop ();
-                return;
+                    cancellable
+                );
+            } catch (Error e) {
+                warning ("[%s] failed to reply with error - %s", method, e.message);
             }
+            return;
+        }
 
-            foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol)) {
-                if (!(btarget_w_sym.second.source_reference.file is TextDocument)) {
-                    // This means we have found references in a file that was added automatically,
-                    // which should not be modified.
-                    // TODO: rewrite all code to use async
-                    string? pkg = btarget_w_sym.second.source_reference.file.package_name;
-                    client.reply_error_async.begin (
+        foreach (var btarget_w_sym in SymbolReferences.get_compilations_using_symbol (selected_project, symbol)) {
+            if (!(btarget_w_sym.second.source_reference.file is TextDocument)) {
+                // This means we have found references in a file that was added automatically,
+                // which should not be modified.
+                // TODO: rewrite all code to use async
+                string? pkg = btarget_w_sym.second.source_reference.file.package_name;
+                Vala.CodeContext.pop ();
+                try {
+                    yield client.reply_error_async (
                         id, 
                         Jsonrpc.ClientError.INVALID_REQUEST, 
                         "Cannot rename a symbol defined in a system library" + (pkg != null ? @" ($pkg)." : "."),
-                        cancellable);
-                    Vala.CodeContext.pop ();
-                    return;
+                        cancellable
+                    );
+                } catch (Error e) {
+                    warning ("[%s] failed to reply with error - %s", method, e.message);
                 }
+                return;
             }
+        }
 
-            try {
-                client.reply (
-                    id,
-                    build_dict (
-                        range: Util.object_to_variant (replacement_range),
-                        placeholder: new Variant.string (symbol.name)
-                    ),
-                    cancellable);
-            } catch (Error e) {
-                warning ("[%s] failed to reply with success - %s", method, e.message);
-            }
-            Vala.CodeContext.pop ();
-        });
+        try {
+            yield client.reply_async (id,
+                build_dict (
+                    range: Util.object_to_variant (replacement_range),
+                    placeholder: new Variant.string (symbol.name)
+                ),
+                cancellable
+            );
+        } catch (Error e) {
+            warning ("[%s] failed to reply with success - %s", method, e.message);
+        }
+        Vala.CodeContext.pop ();
     }
 
     /**
@@ -2057,8 +2130,6 @@ class Vls.Server : Jsonrpc.Server {
         foreach (var project in projects.get_keys_as_array ())
             project.disconnect (projects[project]);
         loop.quit ();
-        foreach (uint id in g_sources)
-            Source.remove (id);
     }
 }
 

--- a/src/server.vala
+++ b/src/server.vala
@@ -135,12 +135,6 @@ class Vls.Server : Jsonrpc.Server {
 
         accept_io_stream (new SimpleIOStream (input_stream, output_stream));
 
-#if WITH_JSONRPC_GLIB_3_30
-        client_closed_event_id = client_closed.connect (client => {
-            shutdown ();
-        });
-#endif
-
         pending_requests = new HashSet<Request> (Request.hash, Request.equal);
 
         this.projects = new HashTable<Project, ulong> (GLib.direct_hash, GLib.direct_equal);
@@ -240,6 +234,12 @@ class Vls.Server : Jsonrpc.Server {
 
         warning ("unhandled notification %s", method);
     }
+
+#if WITH_JSONRPC_GLIB_3_30
+    public override void client_closed (Jsonrpc.Client client) {
+        shutdown ();
+    }
+#endif
 
     // a{sv} only
     public Variant build_dict (...) {

--- a/src/server.vala
+++ b/src/server.vala
@@ -57,12 +57,6 @@ class Vls.Server : Jsonrpc.Server {
      */
     public static Cancellable cancellable = new Cancellable ();
 
-    [CCode (has_target = false)]
-    delegate void NotificationHandler (Vls.Server self, Jsonrpc.Client client, Variant @params);
-
-    [CCode (has_target = false)]
-    delegate void CallHandler (Vls.Server self, Jsonrpc.Client client, string method, Variant id, Variant @params);
-
     ulong client_closed_event_id;
     HashTable<Project, ulong> projects;
     DefaultProject default_project;


### PR DESCRIPTION
I'm investigating use of worker threads to keep the server responsive when compiling large projects. As a first iteration on a solution, we create a worker thread and a temporary `Vala.CodeContext` to compile the updated build target. Then we replace the old code context when we're done.

Additionally, I've converted all the LSP response handlers to async code. This will also keep the server responsive when launching subprocesses and performing I/O.

Problems:
1. There is an increase in memory consumption with this solution. VLS on Geary shoots up to 3.5 GB now. Hence why this is still a draft.
2. It may be possible to avoid recompiling the entire code context in many situations. I need to look into `fast-vapi` and keeping a code context per source file.

TODO:
- [ ] fix increased memory usage
- [ ] fix server's copy of the text document getting out-of-sync with the client, particularly when using undo

Closes #223
Closes #114 