### PR TITLE
WIP, RFC: Add some code actions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,7 @@ version_file = vcs_tag(input: 'version.vala.in',
                        output: 'version.vala',
                        command: ['git', 'describe', '--tags', '--dirty'])
 
-add_project_arguments(['--enable-gobject-tracing', '--fatal-warnings'], language: 'vala')
+add_project_arguments(['--enable-gobject-tracing'], language: 'vala')
 
 extra_vala_sources += files([
   'src/util.vala'

--- a/src/codeaction/implementconstructoraction.vala
+++ b/src/codeaction/implementconstructoraction.vala
@@ -1,0 +1,62 @@
+/* implementconstructoraction.vala
+ *
+ * Copyright 2022 JCWasmx86 <JCWasmx86@t-online.de>
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+using Lsp;
+using Gee;
+
+class Vls.ImplementConstructorAction : CodeAction {
+    public ImplementConstructorAction (Vala.ObjectCreationExpression oce, Vala.Symbol to_be_created) {
+        var target_file = to_be_created.source_reference.file;
+        var insertion_line = to_be_created.source_reference.end.line + 1;
+        var sb = new StringBuilder ();
+        var indent = to_be_created.source_reference.begin.column == 1 ? "" : "\t";
+        sb.append (indent).append (indent).append ("public ").append (oce.member_name.to_string ()).append (" (");
+        var args = oce.get_argument_list ();
+        var idx = 0;
+        for (var i = 0; i < args.size - 1; i++) {
+            sb.append (args[i].value_type.to_string ()).append (" arg%d".printf (idx++)).append (", ");
+        }
+        if (args.size != 0)
+            sb.append (args[args.size - 1].value_type.to_string ()).append (" arg%d".printf (idx));
+        sb.append (") {}\n ");
+        try {
+            var target_uri = Filename.to_uri (target_file.filename);
+            var target_document = new VersionedTextDocumentIdentifier () {
+                uri = target_uri,
+                version = 1
+            };
+            var workspace_edit = new WorkspaceEdit ();
+            var document_edit = new TextDocumentEdit (target_document);
+            var r = new Range.from_sourceref (
+                new Vala.SourceReference (target_file,
+                                          Vala.SourceLocation (null, insertion_line, 1),
+                                          Vala.SourceLocation (null, insertion_line, 1)));
+            var text_edit = new TextEdit (r);
+            document_edit.edits.add (text_edit);
+            workspace_edit.documentChanges = new Gee.ArrayList<TextDocumentEdit> ();
+            workspace_edit.documentChanges.add (document_edit);
+            this.edit = workspace_edit;
+            this.title = "Add constructor";
+            text_edit.newText = sb.str;
+        } catch (ConvertError ce) {
+            error ("Should not happen: %s", ce.message);
+        }
+    }
+}

--- a/src/codeaction/implementnamedconstructoraction.vala
+++ b/src/codeaction/implementnamedconstructoraction.vala
@@ -1,0 +1,69 @@
+/* implementnamedconstructoraction.vala
+ *
+ * Copyright 2022 JCWasmx86 <JCWasmx86@t-online.de>
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+using Lsp;
+using Gee;
+
+class Vls.ImplementNamedConstructorAction : CodeAction {
+    public ImplementNamedConstructorAction (Vala.ObjectCreationExpression oce, Vala.Symbol to_be_created) {
+        var target_file = to_be_created.source_reference.file;
+        var insertion_line = to_be_created.source_reference.end.line + 1;
+        var sb = new StringBuilder ();
+        var indent = to_be_created.source_reference.begin.column == 1 ? "" : "\t";
+        sb.append (indent).append (indent).append ("public ").append (oce.member_name.to_string ()).append ("(");
+        var args = oce.get_argument_list ();
+        var idx = 0;
+        for (var i = 0; i < args.size - 1; i++) {
+            var arg = args[i];
+            arg.check (Vala.CodeContext.get ());
+            var s = arg.value_type.to_string ();
+            sb.append (s == null ? "GLib.Object" : s).append (" arg%d".printf (idx++)).append (", ");
+        }
+        if (args.size != 0) {
+            var last_arg = args[args.size - 1];
+            last_arg.check (Vala.CodeContext.get ());
+            var s = last_arg.value_type.to_string ();
+            sb.append (s == null ? "GLib.Object" : s).append (" arg%d".printf (idx));
+        }
+        sb.append (") {}\n ");
+        try {
+            var target_uri = Filename.to_uri (target_file.filename);
+            var target_document = new VersionedTextDocumentIdentifier () {
+                uri = target_uri,
+                version = 1
+            };
+            var workspace_edit = new WorkspaceEdit ();
+            var document_edit = new TextDocumentEdit (target_document);
+            var r = new Range.from_sourceref (
+                new Vala.SourceReference (target_file,
+                                          Vala.SourceLocation (null, insertion_line, 1),
+                                          Vala.SourceLocation (null, insertion_line, 1)));
+            var text_edit = new TextEdit (r);
+            document_edit.edits.add (text_edit);
+            workspace_edit.documentChanges = new Gee.ArrayList<TextDocumentEdit> ();
+            workspace_edit.documentChanges.add (document_edit);
+            this.edit = workspace_edit;
+            this.title = "Add constructor";
+            text_edit.newText = sb.str;
+        } catch (ConvertError ce) {
+            error ("Should not happen: %s", ce.message);
+        }
+    }
+}

--- a/src/codehelp/codeaction.vala
+++ b/src/codehelp/codeaction.vala
@@ -199,42 +199,7 @@ namespace Vls.CodeActions {
                         // We can't just edit, e.g. some external vapi
                         if (!compilation.get_project_files ().contains (target_file))
                             continue;
-                        var insertion_line = to_be_created.source_reference.end.line + 1;
-                        var sb = new StringBuilder ();
-                        var indent = to_be_created.source_reference.begin.column == 1 ? "" : "\t";
-                        sb.append (indent).append (indent).append ("public ").append (oce.member_name.to_string ()).append (" (");
-                        var args = oce.get_argument_list ();
-                        var idx = 0;
-                        for (var i = 0; i < args.size - 1; i++) {
-                            sb.append (args[i].value_type.to_string ()).append (" arg%d".printf (idx++)).append (", ");
-                        }
-                        if (args.size != 0)
-                            sb.append (args[args.size - 1].value_type.to_string ()).append (" arg%d".printf (idx));
-                        sb.append (") {}\n ");
-                        try {
-                            var target_uri = Filename.to_uri (target_file.filename);
-                            var target_document = new VersionedTextDocumentIdentifier () {
-                                uri = target_uri,
-                                version = 1
-                            };
-                            var workspace_edit = new WorkspaceEdit ();
-                            var document_edit = new TextDocumentEdit (target_document);
-                            var r = new Range.from_sourceref (
-                                new Vala.SourceReference (target_file,
-                                                          Vala.SourceLocation (null, insertion_line, 1),
-                                                          Vala.SourceLocation (null, insertion_line, 1)));
-                            var text_edit = new TextEdit (r);
-                            document_edit.edits.add (text_edit);
-                            workspace_edit.documentChanges = new Gee.ArrayList<TextDocumentEdit> ();
-                            workspace_edit.documentChanges.add (document_edit);
-                            var ca = new CodeAction ();
-                            ca.edit = workspace_edit;
-                            ca.title = "Add constructor";
-                            text_edit.newText = sb.str;
-                            code_actions.add (ca);
-                        } catch (ConvertError ce) {
-                            error ("Should not happen: %s", ce.message);
-                        }
+                        code_actions.add (new ImplementConstructorAction (oce, to_be_created));
                     } else if (diag.message.contains ("The name ") && diag.message.contains ("does not exist in the context of")) {
                         var to_be_created = oce.member_name.inner.symbol_reference;
                         if (!(to_be_created is Vala.Class)) {
@@ -248,49 +213,6 @@ namespace Vls.CodeActions {
                         // We can't just edit, e.g. some external vapi
                         if (!compilation.get_project_files ().contains (target_file))
                             continue;
-                        var insertion_line = to_be_created.source_reference.end.line + 1;
-                        var sb = new StringBuilder ();
-                        var indent = to_be_created.source_reference.begin.column == 1 ? "" : "\t";
-                        sb.append (indent).append (indent).append ("public ").append (oce.member_name.to_string ()).append ("(");
-                        var args = oce.get_argument_list ();
-                        var idx = 0;
-                        for (var i = 0; i < args.size - 1; i++) {
-                            var arg = args[i];
-                            arg.check (CodeContext.get ());
-                            var s = arg.value_type.to_string ();
-                            sb.append (s == null ? "GLib.Object" : s).append (" arg%d".printf (idx++)).append (", ");
-                        }
-                        if (args.size != 0) {
-                            var last_arg = args[args.size - 1];
-                            last_arg.check (CodeContext.get ());
-                            var s = last_arg.value_type.to_string ();
-                            sb.append (s == null ? "GLib.Object" : s).append (" arg%d".printf (idx));
-                        }
-                        sb.append (") {}\n ");
-                        try {
-                            var target_uri = Filename.to_uri (target_file.filename);
-                            var target_document = new VersionedTextDocumentIdentifier () {
-                                uri = target_uri,
-                                version = 1
-                            };
-                            var workspace_edit = new WorkspaceEdit ();
-                            var document_edit = new TextDocumentEdit (target_document);
-                            var r = new Range.from_sourceref (
-                                new Vala.SourceReference (target_file,
-                                                          Vala.SourceLocation (null, insertion_line, 1),
-                                                          Vala.SourceLocation (null, insertion_line, 1)));
-                            var text_edit = new TextEdit (r);
-                            document_edit.edits.add (text_edit);
-                            workspace_edit.documentChanges = new Gee.ArrayList<TextDocumentEdit> ();
-                            workspace_edit.documentChanges.add (document_edit);
-                            var ca = new CodeAction ();
-                            ca.edit = workspace_edit;
-                            ca.title = "Add constructor";
-                            text_edit.newText = sb.str;
-                            code_actions.add (ca);
-                        } catch (ConvertError ce) {
-                            error ("Should not happen: %s", ce.message);
-                        }
                     }
                 }
             }

--- a/src/codehelp/codeaction.vala
+++ b/src/codehelp/codeaction.vala
@@ -23,13 +23,13 @@ using Vala;
 
 namespace Vls.CodeActions {
     /**
-     * Extracts a list of code actions for the given document and range.
+     * Extracts a list of code actions for the given document and range using the AST and the diagnostics.
      *
      * @param file      the current document
      * @param range     the range to show code actions for
      * @param uri       the document URI
      */
-    Collection<CodeAction> extract (Compilation compilation, TextDocument file, Range range, string uri) {
+    Collection<CodeAction> generate_codeactions (Compilation compilation, TextDocument file, Range range, string uri, Reporter reporter) {
         // search for nodes containing the query range
         var finder = new NodeSearch (file, range.start, true, range.end);
         var code_actions = new ArrayList<CodeAction> ();
@@ -42,12 +42,12 @@ namespace Vls.CodeActions {
         // add code actions
         foreach (CodeNode code_node in finder.result) {
             if (code_node is IntegerLiteral) {
-                var lit = (IntegerLiteral)code_node;
+                var lit = (IntegerLiteral) code_node;
                 var lit_range = new Range.from_sourceref (lit.source_reference);
                 if (lit_range.contains (range.start) && lit_range.contains (range.end))
                     code_actions.add (new BaseConverterAction (lit, document));
             } else if (code_node is Class) {
-                var csym = (Class)code_node;
+                var csym = (Class) code_node;
                 var clsdef_range = compute_class_def_range (csym, class_ranges);
                 var cls_range = new Range.from_sourceref (csym.source_reference);
                 if (cls_range.contains (range.start) && cls_range.contains (range.end)) {
@@ -60,7 +60,66 @@ namespace Vls.CodeActions {
             }
         }
 
+        find_actionable_diagnostics (code_actions, document, file, range, reporter);
+
         return code_actions;
+    }
+
+    void find_actionable_diagnostics (Vala.ArrayList<Lsp.CodeAction> code_actions, VersionedTextDocumentIdentifier document, TextDocument file, Range range, Reporter reporter) {
+        foreach (var diagnostic in reporter.messages) {
+            if (file.filename != diagnostic.loc.file.filename)
+                continue;
+            var location = new Range.from_sourceref (diagnostic.loc);
+            // Should this be AND or OR?
+            var matches = location.contains (range.start) || location.contains (range.end);
+            if (!matches)
+                continue;
+            var workspace_edit = new WorkspaceEdit ();
+            var document_edit = new TextDocumentEdit (document);
+            var text_edit = new TextEdit (location);
+            document_edit.edits.add (text_edit);
+            workspace_edit.documentChanges = new Gee.ArrayList<TextDocumentEdit> ();
+            workspace_edit.documentChanges.add (document_edit);
+            var ca = new CodeAction ();
+            ca.edit = workspace_edit;
+            var msg = diagnostic.message;
+            if (msg == "[Deprecated] is deprecated. Use [Version (deprecated = true, deprecated_since = \"\", replacement = \"\")]") {
+                // No [], as the range excludes those chars
+                text_edit.newText = "Version (deprecated = true, deprecated_since = \"\", replacement = \"\")";
+                ca.title = "Use [Version (deprecated = true, deprecated_since = \"\", replacement = \"\")]";
+            } else if (msg == "[NoArrayLength] is deprecated, use [CCode (array_length = false)] instead.") {
+                text_edit.newText = "CCode (array_length = false)";
+                ca.title = "Use [CCode (array_length = false)]";
+            } else if (msg == "[Experimental] is deprecated. Use [Version (experimental = true, experimental_until = \"\")]") {
+                text_edit.newText = "Version (experimental = true, experimental_until = \"\")";
+                ca.title = "Use [Version (experimental = true, experimental_until = \"\")]";
+            } else if (msg == "Assignment to same variable") {
+                text_edit.newText = "";
+                var line = file.get_source_line (diagnostic.loc.end.line);
+                var before_same_assignment = line.substring (0, diagnostic.loc.begin.column);
+                if (before_same_assignment.strip () == "")
+                    text_edit.range.start.character = 0;
+                var after_same_assignment = line.substring (diagnostic.loc.end.column);
+                var idx = 0;
+                var found_semicolon = -1;
+                while (idx < after_same_assignment.length) {
+                    if (after_same_assignment[idx] == ';') {
+                        found_semicolon = idx;
+                    } else if (after_same_assignment[idx] == '/'
+                               && idx + 1 < after_same_assignment.length
+                               && after_same_assignment[idx + 1] == '/') {
+                        break;
+                    }
+                    idx++;
+                }
+                if (found_semicolon != -1)
+                    text_edit.range.end.character += idx;
+                ca.title = "Remove assignment";
+            } else {
+                continue;
+            }
+            code_actions.add (ca);
+        }
     }
 
     /**
@@ -72,11 +131,11 @@ namespace Vls.CodeActions {
         // otherwise compute the result and cache it
         // csym.source_reference must be non-null otherwise NodeSearch wouldn't have found csym
         var pos = new Position.from_libvala (csym.source_reference.end);
-        var offset = csym.source_reference.end.pos - (char *)csym.source_reference.file.content;
+        var offset = csym.source_reference.end.pos - (char*) csym.source_reference.file.content;
         var dl = 0;
         var dc = 0;
-        while (offset < csym.source_reference.file.content.length && csym.source_reference.file.content[(long)offset] != '{') {
-            if (Util.is_newline (csym.source_reference.file.content[(long)offset])) {
+        while (offset < csym.source_reference.file.content.length && csym.source_reference.file.content[(long) offset] != '{') {
+            if (Util.is_newline (csym.source_reference.file.content[(long) offset])) {
                 dl++;
                 dc = 0;
             } else {
@@ -93,8 +152,8 @@ namespace Vls.CodeActions {
             if (member.source_reference == null)
                 continue;
             range = range.union (new Range.from_sourceref (member.source_reference));
-            if (member is Method && ((Method)member).body != null && ((Method)member).body.source_reference != null)
-                range = range.union (new Range.from_sourceref (((Method)member).body.source_reference));
+            if (member is Method && ((Method) member).body != null && ((Method) member).body.source_reference != null)
+                range = range.union (new Range.from_sourceref (((Method) member).body.source_reference));
         }
         class_ranges[csym] = range;
         return range;

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,8 @@ vls_src = files([
   'analysis/codestyleanalyzer.vala',
   'analysis/symbolenumerator.vala',
   'codeaction/baseconverteraction.vala',
+  'codeaction/implementconstructoraction.vala',
+  'codeaction/implementnamedconstructoraction.vala',
   'codeaction/implementmissingprereqsaction.vala',
   'codehelp/callhierarchy.vala',
   'codehelp/codeaction.vala',

--- a/src/server.vala
+++ b/src/server.vala
@@ -1645,7 +1645,7 @@ class Vls.Server : Jsonrpc.Server {
         var json_array = new Json.Array ();
 
         Vala.CodeContext.push (compilation.code_context);
-        var code_actions = CodeActions.extract (compilation, (TextDocument) source_file, p.range, Uri.unescape_string (p.textDocument.uri));
+        var code_actions = CodeActions.generate_codeactions (compilation, (TextDocument) source_file, p.range, Uri.unescape_string (p.textDocument.uri), compilation.reporter);
         foreach (var action in code_actions)
             json_array.add_element (Json.gobject_serialize (action));
         Vala.CodeContext.pop ();


### PR DESCRIPTION
This adds several code actions:

1. Trivial code actions that are basically just Replacing some expression (Although here you could discuss whether it even makes sense to have these)
2. Add constructor (`new Foo ()`)
3. Add named constructor (`new Foo.bar ()`)
4. (WIP) Add method

2) and 3) should be quite acceptable, but in (4) I have a lot of problems:

1. Resolving the class where the method should be added, requires a lot of guesswork/messy code as it seems like libvala sees an error and does not resolve the call/MemberAccess further. I attempted to implement something similar, so at least basic things work, but this is really messy.
2. The same with the parameters, while I could just `check` them in 3) and it worked, all parameters seem to resolve to `null` or then - after fixing it manually - to `GLib.Object`


TODO:
- [ ] Agree on everything, discuss especially 4)
- [ ] Fix the code
- [ ] Add --fatal-warnings again
- [ ] Cleanup the code
- [ ] Fix build for older vala versions
- [ ] Write a bit of documentation