### PR TITLE
Fix crash, if an invalid file is sent by the client.

### DIFF
--- a/src/server.vala
+++ b/src/server.vala
@@ -290,7 +290,8 @@ class Vls.Server : Jsonrpc.Server {
         // fallback to default project
         if (selected_project == null) {
             results = default_project.lookup_compile_input_source_file (uri);
-            selected_project = default_project;
+            if (!results.is_empty)
+                selected_project = default_project;
         }
 
         if (selected_project != null) {


### PR DESCRIPTION
This *should* not happen, but at least for GNOME-Builder,coupled with a second language server, it fixes crashes.

This workaround can probably be removed after the GTK4-Port