### PR TITLE
Improved formatter

### DIFF
--- a/src/codehelp/formatter.vala
+++ b/src/codehelp/formatter.vala
@@ -33,8 +33,7 @@ namespace Vls.Formatter {
                      Cancellable? cancellable = null) throws FormattingError, Error {
         // SEARCH_PATH_FROM_ENVP does not seem to be available even in quite fast distros like Fedora 35,
         // so we have to use a SubprocessLauncher and call set_environ()
-        var launcher = new SubprocessLauncher (SubprocessFlags.STDERR_PIPE | SubprocessFlags.STDOUT_PIPE
-                                               | SubprocessFlags.STDIN_PIPE);
+        var launcher = new SubprocessLauncher (SubprocessFlags.STDERR_PIPE | SubprocessFlags.STDOUT_PIPE | SubprocessFlags.STDIN_PIPE);
         launcher.set_environ (Environ.get ());
         var args = get_uncrustify_args (source, options, analyzed_style, cancellable);
         Subprocess subprocess = launcher.spawnv (args);
@@ -52,10 +51,10 @@ namespace Vls.Formatter {
             if (stderr_buf != null && stderr_buf.strip ().length > 0) {
                 throw new FormattingError.FORMAT ("%s", stderr_buf);
             } else {
+                var sb = new StringBuilder ();
                 foreach (var arg in args)
-                    stderr.printf ("%s ", arg);
-                stderr.printf ("\n");
-                throw new FormattingError.READ ("uncrustify failed with error code %d", subprocess.get_exit_status ());
+                    sb.append (arg).append (" ");
+                throw new FormattingError.READ ("uncrustify failed with error code %d: %s", subprocess.get_exit_status (), sb.str.strip ());
             }
         }
         Range edit_range;

--- a/src/codehelp/formatter.vala
+++ b/src/codehelp/formatter.vala
@@ -41,8 +41,8 @@ namespace Vls.Formatter {
         if (range == null) {
             stdin_buf = source.content;
         } else {
-            var from = (long) Util.get_string_pos (source.content, range.start.line, range.start.character);
-            var to = (long) Util.get_string_pos (source.content, range.end.line, range.end.character);
+            var from = (long)Util.get_string_pos (source.content, range.start.line, range.start.character);
+            var to = (long)Util.get_string_pos (source.content, range.end.line, range.end.character);
             stdin_buf = source.content[from:to];
         }
         string? stdout_buf = null, stderr_buf = null;
@@ -78,10 +78,7 @@ namespace Vls.Formatter {
         return new TextEdit (edit_range, stdout_buf);
     }
 
-    string[] get_uncrustify_args (Vala.SourceFile source,
-                                  FormattingOptions options,
-                                  CodeStyleAnalyzer? analyzed_style,
-                                  Cancellable? cancellable = null) {
+    string[] get_uncrustify_args (Vala.SourceFile source, FormattingOptions options, CodeStyleAnalyzer? analyzed_style, Cancellable? cancellable = null) {
         // Check if the project has a local uncrustify config file and use that instead
         var cwd = File.new_for_path (Environment.get_current_dir ());
         string[] config_paths = { ".uncrustify.cfg", "uncrustify.cfg" };

--- a/src/codehelp/formatter.vala
+++ b/src/codehelp/formatter.vala
@@ -187,13 +187,13 @@ namespace Vls.Formatter {
             conf["sp_func_def_paren"] = "force";
             conf["sp_func_class_paren"] = "force";
             conf["sp_func_call_paren"] = "force";
-            conf["sp_vala_after_translation"] = "remove";
         } else {
             conf["sp_func_proto_paren"] = "remove";
             conf["sp_func_def_paren"] = "remove";
             conf["sp_func_class_paren"] = "remove";
             conf["sp_func_call_paren"] = "remove";
         }
+        conf["sp_vala_after_translation"] = "remove";
         conf["sp_func_call_paren_empty"] = "ignore";
         conf["sp_return_paren"] = "force";
         conf["sp_attribute_paren"] = "force";

--- a/src/codehelp/formatter.vala
+++ b/src/codehelp/formatter.vala
@@ -99,11 +99,7 @@ namespace Vls.Formatter {
         conf["nl_end_of_file"] = options.insertFinalNewline ? "force" : "remove";
         conf["nl_end_of_file_min"] = "%d".printf (options.trimFinalNewlines ? 1 : 0);
         conf["output_tab_size"] = "%u".printf (options.tabSize);
-        conf["code_width"] = "120";
         conf["pos_arith"] = "lead";
-        conf["ls_for_split_full"] = "true";
-        conf["ls_func_split_full"] = "true";
-        conf["ls_code_width"] = "true";
         conf["indent_paren_nl"] = "true";
         conf["indent_comma_brace"] = "1";
         conf["indent_columns"] = "4";

--- a/src/codehelp/formatter.vala
+++ b/src/codehelp/formatter.vala
@@ -146,8 +146,10 @@ namespace Vls.Formatter {
         conf["sp_inside_angle"] = "remove";
         conf["sp_after_angle"] = "remove";
         conf["sp_angle_paren"] = "force";
+        conf["sp_angle_paren_empty"] = "force";
         conf["sp_angle_word"] = "force";
         conf["sp_angle_shift"] = "remove";
+        conf["sp_permit_cpp11_shift"] = "true";
         conf["sp_before_sparen"] = "force";
         conf["sp_inside_sparen"] = "remove";
         conf["sp_after_sparen"] = "remove";


### PR DESCRIPTION
This improves the formatter:

1. Break long lines (At the moment 120, but this should be configurable somehow, maybe use the average or something like that)
2. Indent broken up parameter lists
3. Fix `_("Foo")` and so on
4. Fix the bug that `new Gee.HashMap<string, List<string>> ()` is reformatted as `new Gee.HashMap<string, List<string> > ()`
5. If formatting fails, print commandline to stderr in order to debug e.g. uncrustify failures