### PR TITLE
Fix #259

### DIFF
--- a/src/documentation/girdocumentation.vala
+++ b/src/documentation/girdocumentation.vala
@@ -280,7 +280,7 @@ class Vls.GirDocumentation {
      * see [[https://developer.gnome.org/gtk-doc-manual/stable/documenting_syntax.html.en]]
      */
     public string render_gtk_doc_content (string content, Vala.Comment comment, Compilation compilation) throws GLib.RegexError {
-        string comment_data = content;  // FIXME: workaround for valac codegen bug
+        string comment_data = content.dup();  // FIXME: workaround for valac codegen bug
 
         // replace code blocks
         comment_data = /\|\[(<!-- language="(\w+)" -->)?((.|\s)*?)\]\|/


### PR DESCRIPTION
This fixes #259. There's probably a better way - what I did is just duplicate `content` to fix ownership issues.