### PR TITLE
README.md: note GNOME Builder plugin included upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ endif
 
 ### GNOME Builder
 - requires GNOME Builder >= 3.35
+- - GNOME Builder >= 3.41 comes with plugin preinstalled and enabled
 - Running `ninja -C build install` should install the third-party plugin to `$PREFIX/lib/gnome-builder/plugins`. Enable `Vala` and disable `GNOME Vala Language Server`.
 
 ### Kate


### PR DESCRIPTION
I've just spent half an hour trying to figure out why AUR package wasn't installing GNOME Builder plugin only to find out it was upstreamed and its installation is disabled in this package for GNOME Builder >= 41. Note this in README to avoid such frustration in the future.