### PR TITLE
meson: support settings overrides from editor

### DIFF
--- a/src/projects/mesonproject.vala
+++ b/src/projects/mesonproject.vala
@@ -27,6 +27,8 @@ class Vls.MesonProject : Project {
     private string build_dir;
     private bool configured_once;
     private bool requires_general_build;
+    private string[] extra_setup_args = {};
+    private string[] extra_compile_args = {};
 
     /**
      * Substitute special arguments like `@INPUT@` and `@OUTPUT@` as they
@@ -208,6 +210,9 @@ class Vls.MesonProject : Project {
                 string[] spawn_args = {"meson", "introspect", @"--$subst_command", "."};
                 string proc_stdout, proc_stderr;
                 int proc_status;
+
+                foreach (string arg in extra_setup_args)
+                    spawn_args += arg;
 
                 string command_str = "";
                 foreach (string part in spawn_args) {
@@ -761,9 +766,13 @@ class Vls.MesonProject : Project {
         if (requires_general_build) {
             int proc_status;
             string proc_stdout, proc_stderr;
+            string[] spawn_args = {"meson", "compile"};
+
+            foreach (string arg in extra_compile_args)
+                spawn_args += arg;
 
             Process.spawn_sync (build_dir,
-                                {"meson", "compile"},
+                                spawn_args,
                                 null,
                                 SpawnFlags.SEARCH_PATH,
                                 null,
@@ -781,9 +790,28 @@ class Vls.MesonProject : Project {
         base.build_if_stale (cancellable);
     }
 
-    public MesonProject (string root_path, FileCache file_cache, Cancellable? cancellable = null) throws Error {
+    public MesonProject (string root_path, FileCache file_cache,
+                         Lsp.EditorOptions? editor_options,
+                         Cancellable? cancellable = null) throws Error {
         base (root_path, file_cache);
-        this.build_dir = DirUtils.make_tmp (@"vls-meson-$(str_hash (root_path))-XXXXXX");
+        var default_build_dir_template = @"vls-meson-$(str_hash (root_path))-XXXXXX";
+        if (editor_options != null) {
+            debug ("overriding with VSCode Meson plugin settings: %s", 
+                   Json.gobject_to_data (editor_options, null));
+            this.extra_setup_args = editor_options.mesonConfigureOptions;
+            this.extra_compile_args = editor_options.mesonCompileOptions;
+            if (editor_options.mesonBuildDir != null) {
+                var meson_build_dir = File.new_for_path (editor_options.mesonBuildDir);
+                try {
+                    meson_build_dir.make_directory_with_parents (cancellable);
+                    this.build_dir = editor_options.mesonBuildDir;
+                } catch (IOError.EXISTS e) {
+                    // ignore whether the build folder exists
+                }
+            }
+        }
+        if (this.build_dir == null)
+            this.build_dir = DirUtils.make_tmp (default_build_dir_template);
         reconfigure_if_stale (cancellable);
     }
 

--- a/src/protocol.vala
+++ b/src/protocol.vala
@@ -693,11 +693,38 @@ namespace Lsp {
         public TextDocumentClientCapabilities textDocument { get; set; default = new TextDocumentClientCapabilities (); }
     }
 
+    /**
+     * (Custom) Editor type for {@link EditorOptions}
+     */
+    enum EditorType {
+        UNKNOWN = 0,
+        VSCODE  = 1
+    }
+
+    /**
+     * (Custom) extra settings and capabilities of the editor.
+     * These may be overrides for projects. This is not LSP-specific.
+     */
+    class EditorOptions : Object {
+        public EditorType editorType { get; set; }
+        public string[] mesonConfigureOptions { get; set; }
+        public string[] mesonCompileOptions { get; set; }
+        private string? _mesonBuildDir;
+        public string? mesonBuildDir {
+            get { return _mesonBuildDir; }
+            set { 
+                if (value != null && value.length > 0)
+                    _mesonBuildDir = value; 
+            }
+        }
+    }
+
     class InitializeParams : Object {
         public int processId { get; set; }
         public string? rootPath { get; set; }
         public string? rootUri { get; set; }
         public ClientCapabilities capabilities { get; set; default = new ClientCapabilities (); }
+        public EditorOptions? initializationOptions { get; set; }
     }
 
     class SignatureInformation : Object, Json.Serializable {

--- a/src/server.vala
+++ b/src/server.vala
@@ -400,11 +400,13 @@ class Vls.Server : Jsonrpc.Server {
         // TODO: autotools, make(?), cmake(?)
         if (meson_file.query_exists (cancellable)) {
             try {
-                backend_project = new MesonProject (root_path, file_cache, cancellable);
+                backend_project = new MesonProject (root_path, file_cache,
+                                                    init_params.initializationOptions, cancellable);
+            } catch (ProjectError.VERSION_UNSUPPORTED e) {
+                // ignore and skip to the next project
+                show_message (client, @"Won't use Meson project - $(e.message)", MessageType.Warning);
             } catch (Error e) {
-                if (!(e is ProjectError.VERSION_UNSUPPORTED)) {
-                    show_message (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
-                }
+                show_message (client, @"Failed to initialize Meson project - $(e.message)", MessageType.Error);
             }
         }
         


### PR DESCRIPTION
This introduces settings overrides (`EditorOptions`) passed from the editor to the server in the initialize() call. These overrides are just currently for the Meson backend. The intent is to have the vala-vscode extension send these options from the Meson VSCode extension to VLS.

Closes #304 
Closes #305