### PR TITLE
Add warning to Kate instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ require'lspconfig'.vala_ls.setup {
 
 ### Kate
 - officially supported in Kate git master
+- **Warning:** Kate will silently fail to find symbols when meson cannot be found in path without notifying the user.
 
 ### Emacs
 - supported with the [lsp-mode](https://github.com/emacs-lsp/lsp-mode) plugin


### PR DESCRIPTION
Kate will not show any indication that meson cannot be found in path when loading a meson project, and will instead fail silently and fail to load any dependencies. Other editors such as VS Code do show an error.

It took a stupid amount of time before I opened it with VS Code and got an error that meson wasn't available in $PATH.