### PR TITLE
return 0 with --version parameter

### DIFF
--- a/src/server.vala
+++ b/src/server.vala
@@ -2419,7 +2419,7 @@ int main (string[] args) {
 
     if (opt_version) {
         stdout.printf ("%s %s\n", Config.PROJECT_NAME, Config.PROJECT_VERSION);
-        return 1;
+        return 0;
     }
 
     // otherwise


### PR DESCRIPTION
return 0 instead 1 with --version
because we can't know if vala-language-server work or not (for script)